### PR TITLE
[Feature] #35 자체 로그인 화면 구현, Material 스타일로 전환

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/login/OtherLoginFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/login/OtherLoginFragment.kt
@@ -1,0 +1,48 @@
+package kr.co.lion.modigm.ui.login
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import kr.co.lion.modigm.R
+import kr.co.lion.modigm.databinding.FragmentLoginBinding
+import kr.co.lion.modigm.databinding.FragmentOtherLoginBinding
+
+class OtherLoginFragment : Fragment() {
+
+    private lateinit var binding : FragmentOtherLoginBinding
+
+
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        // 바인딩
+        binding = FragmentOtherLoginBinding.inflate(inflater,container,false)
+        return binding.root
+    }
+
+    // view
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // 초기 뷰 세팅
+        initView()
+    }
+
+
+    // 초기 뷰 세팅
+    fun initView(){
+
+        // 바인딩
+        with(binding){
+
+
+            // 로고
+
+            // 버튼
+
+
+        }
+    }
+
+}

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -23,7 +23,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <ImageView
+        <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/imageViewLoginLogo"
             android:layout_width="150dp"
             android:layout_height="150dp"
@@ -35,7 +35,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/textViewLoginTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -50,7 +50,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/imageViewLoginLogo" />
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/textViewLoginSecondTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -75,7 +75,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/textViewLoginSecondTitle" />
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/textViewLoginOtherLogin"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_other_login.xml
+++ b/app/src/main/res/layout/fragment_other_login.xml
@@ -6,7 +6,8 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:padding="16dp"
-    tools:context=".ui.login.OtherLoginFragment">
+    tools:context=".ui.login.OtherLoginFragment"
+    android:transitionGroup="true">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/textViewOtherTitle"

--- a/app/src/main/res/layout/fragment_other_login.xml
+++ b/app/src/main/res/layout/fragment_other_login.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp"
+    tools:context=".ui.login.OtherLoginFragment">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/textViewOtherTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="100dp"
+        android:text="모우다임"
+        android:textColor="@color/black"
+        android:textSize="40dp"
+        android:textStyle="bold" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/textViewOtherSecondTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="개발자 스터디의 새로운 패러다임"
+        android:textColor="@color/black"
+        android:textSize="18dp"
+        android:textStyle="bold" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/TextInputLayoutOtherEmail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:endIconMode="clear_text"
+        app:hintAnimationEnabled="false"
+        app:hintEnabled="false"
+        android:layout_marginTop="30dp">
+        <!--app:startIconDrawable="@drawable/icon_person_24px"-->
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/TextInputEditOtherEmail"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="이메일"
+            android:inputType="text|textEmailAddress"
+            android:textSize="16dp" />
+    </com.google.android.material.textfield.TextInputLayout>
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/TextInputLayoutOtherPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:endIconMode="clear_text"
+        app:hintAnimationEnabled="false"
+        app:hintEnabled="false"
+        android:layout_marginTop="20dp">
+        <!--app:startIconDrawable="@drawable/icon_person_24px"-->
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/TextInputEditOtherPassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="비밀번호"
+            android:inputType="text|textPassword"
+            android:textSize="16dp" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="0dp">
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/checkBoxOtherAutoLogin"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="자동 로그인" />
+
+        <com.google.android.material.button.MaterialButton
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:id="@+id/buttonOtherSearchEmail"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="이메일   |"
+            android:padding="0dp"
+            android:textColor="@color/black" />
+        <com.google.android.material.button.MaterialButton
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:id="@+id/buttonOtherSearchPassword"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="비밀번호 찾기"
+            android:padding="0dp"
+            android:textColor="@color/black" />
+
+
+    </LinearLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonOtherLogin"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="로그인"/>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:textAlignment="center"
+        android:gravity="center">
+        <com.google.android.material.textview.MaterialTextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="계정이 없으신가요? "
+            app:insetTop="0dp"
+            app:insetBottom="0dp"
+            app:insetStart="0dp"
+            app:insetEnd="0dp"
+            android:padding="0dp"
+            />
+        <com.google.android.material.button.MaterialButton
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:id="@+id/buttonOtherJoin"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="회원가입"
+            android:textColor="@color/black"
+            android:textStyle="bold"
+            android:padding="0dp"
+            app:insetTop="0dp"
+            app:insetBottom="0dp"
+            app:insetStart="0dp"
+            app:insetEnd="0dp"
+            />
+    </LinearLayout>
+
+
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_other_login.xml
+++ b/app/src/main/res/layout/fragment_other_login.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="16dp"
+    android:paddingHorizontal="16dp"
     tools:context=".ui.login.OtherLoginFragment"
     android:transitionGroup="true">
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #35

## 📝작업 내용

> 자체로그인 화면 구현입니다. 
트랜지션그룹도 설정했습니다.

### 스크린샷 (선택)
![image](https://github.com/APP-Android2/FinalProject-modigm/assets/79239041/bdaf683a-d798-4d2a-8906-5d71bdc24996)

## 💬리뷰 요구사항(선택)
역시 글꼴 미적용이에요!
버튼(텍스트버튼), 텍스트뷰, 체크박스 등 웬만하면 상위호환인 Material로 설정하려합니다.
추후 앱 구동 시에 테마문제가 있을지 모르겠는데, 문제가 생긴다면 빠르게 수정하겠습니다..ㅎㅎ
