### PR TITLE
[#45] feat - ChatRoom 채팅방, 대화내용 (Group, 1:1) 분리

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatGroupFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatGroupFragment.kt
@@ -6,20 +6,13 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat
-import androidx.databinding.DataBindingUtil
-import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kr.co.lion.modigm.databinding.FragmentChatGroupBinding
 import kr.co.lion.modigm.databinding.RowChatroomFiledBinding
 import kr.co.lion.modigm.ui.MainActivity
+import kr.co.lion.modigm.ui.chat.adapter.ChatRoomAdapter
 import kr.co.lion.modigm.util.FragmentName
-import java.text.NumberFormat
-import java.util.Locale
 
 class ChatGroupFragment : Fragment() {
 
@@ -32,51 +25,45 @@ class ChatGroupFragment : Fragment() {
         mainActivity = activity as MainActivity
 
         // Recycler 뷰
-        settingRecyclerViewChatRoom()
+        setupRecyclerView()
 
         return fragmentChatGroupBinding.root
     }
 
-    // Recycler 뷰 설정
-    fun settingRecyclerViewChatRoom() {
-        fragmentChatGroupBinding.apply {
-            recyclerViewChatGroup.apply {
-                // 어뎁터 및 레이아웃 매니저 설정
-                adapter = ChatGroupRecyclerViewAdapter()
-                layoutManager = LinearLayoutManager(mainActivity)
-            }
-        }
-    }
+    // RecyclerView 초기화
+    private fun setupRecyclerView() {
+        // 대화방 목록 데이터 생성 (임시)
+        val roomList = listOf(
+            ChatRoomItem(
+                chatIdx = 4,
+                chatTitle = "Kotlin 스터디 모집",
+                chatMemberList = listOf("currentUser", "sonUser", "iuUser", "ryuUser"),
+                participantCount = 4,
+                isGroupChat = true
+            ),
+            ChatRoomItem(
+                chatIdx = 5,
+                chatTitle = "Modigm 멤버 모임",
+                chatMemberList = listOf("currentUser", "swUser", "tjUser", "hwUser", "msUser", "shUser"),
+                participantCount = 6,
+                isGroupChat = true
+            ),
+            ChatRoomItem(
+                chatIdx = 6,
+                chatTitle = "제 11회 해커톤 준비반",
+                chatMemberList = listOf("currentUser", "sonUser", "iuUser", "ryuUser"),
+                participantCount = 4,
+                isGroupChat = true
+            ),
+        )
 
-    // 그룹 채팅(참여 중 탭) Recycler 뷰 어댑터 세팅
-    inner class ChatGroupRecyclerViewAdapter: RecyclerView.Adapter<ChatGroupRecyclerViewAdapter.ChatGroupViewHolder>(){
-        inner class ChatGroupViewHolder(rowChatroomFiledBinding: RowChatroomFiledBinding): RecyclerView.ViewHolder(rowChatroomFiledBinding.root){
-            val rowChatroomFiledBinding: RowChatroomFiledBinding
-            init {
-                this.rowChatroomFiledBinding = rowChatroomFiledBinding
-
-                this.rowChatroomFiledBinding.root.layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-                )
-            }
-        }
-
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChatGroupViewHolder {
-            val rowChatroomFiledBinding = RowChatroomFiledBinding.inflate(layoutInflater)
-            val chatGroupViewHolder = ChatGroupViewHolder(rowChatroomFiledBinding)
-
-            return chatGroupViewHolder
-        }
-
-        override fun getItemCount(): Int {
-            return 6
-        }
-
-        override fun onBindViewHolder(holder: ChatGroupViewHolder, position: Int) {
-            holder.rowChatroomFiledBinding.root.setOnClickListener {
-                mainActivity.replaceFragment(FragmentName.CHAT_ROOM, true, true, null)
-            }
+        // 대화방 목록 RecyclerView 설정
+        fragmentChatGroupBinding.recyclerViewChatGroup.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = ChatRoomAdapter(roomList, { roomItem ->
+                // 대화방 선택 시 동작
+                Log.d("test1234", "Selected Room: ${roomItem.chatTitle}")
+            }, mainActivity)
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatOnetoOneFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatOnetoOneFragment.kt
@@ -7,22 +7,19 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentChatOnetoOneBinding
-import kr.co.lion.modigm.databinding.RowChatroomFiledBinding
 import kr.co.lion.modigm.ui.MainActivity
 import kr.co.lion.modigm.ui.chat.adapter.ChatRoomAdapter
-import kr.co.lion.modigm.util.FragmentName
 
 // 대화방 아이템을 나타내는 데이터 클래스
 data class ChatRoomItem(
     val chatIdx: Int, // 채팅방 고유 ID
     val chatTitle: String, // 채팅방 이름
-    val chatMemberList: List<String> = listOf("currentUser", "iuUser"), // 채팅방 참여 멤버 UID 목록
+    val chatMemberList: List<String>, // 채팅방 참여 멤버 UID 목록
     val participantCount: Int = 0, // 참여자 수 (그룹 채팅방일 때만 해당)
     val isGroupChat: Boolean = false // 그룹 채팅방 여부
 )
+
 class ChatOnetoOneFragment : Fragment() {
 
     lateinit var fragmentChatOnetoOneBinding: FragmentChatOnetoOneBinding
@@ -30,36 +27,34 @@ class ChatOnetoOneFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         fragmentChatOnetoOneBinding = FragmentChatOnetoOneBinding.inflate(layoutInflater)
-        val view = fragmentChatOnetoOneBinding.root
         mainActivity = activity as MainActivity
 
-        val recyclerView: RecyclerView = view.findViewById(R.id.recyclerViewChatOnetoOne)
+        // RecyclerView 초기화
+        setupRecyclerView()
 
+        return fragmentChatOnetoOneBinding.root
+    }
+
+    // RecyclerView 초기화
+    private fun setupRecyclerView() {
         // 대화방 목록 데이터 생성 (임시)
         val roomList = listOf(
             ChatRoomItem(
                 chatIdx = 1,
-                chatTitle = "그룹 채팅방 1",
-                chatMemberList = listOf("currentUser", "sonUser", "iuUser", "ryuUser"),
-                participantCount = 4,
-                isGroupChat = true
-            ),
-            ChatRoomItem(
-                chatIdx = 2,
                 chatTitle = "류현진",
                 chatMemberList = listOf("currentUser", "ryuUser"),
                 participantCount = 2,
                 isGroupChat = false
             ),
             ChatRoomItem(
-                chatIdx = 3,
+                chatIdx = 2,
                 chatTitle = "아이유",
                 chatMemberList = listOf("currentUser", "iuUser"),
                 participantCount = 2,
                 isGroupChat = false
             ),
             ChatRoomItem(
-                chatIdx = 4,
+                chatIdx = 3,
                 chatTitle = "손흥민",
                 chatMemberList = listOf("currentUser", "sonUser"),
                 participantCount = 2,
@@ -75,55 +70,5 @@ class ChatOnetoOneFragment : Fragment() {
                 Log.d("test1234", "Selected Room: ${roomItem.chatTitle}")
             }, mainActivity)
         }
-
-        // Recycler 뷰
-//        settingRecyclerViewChatRoom()
-
-        return fragmentChatOnetoOneBinding.root
     }
-
-    // Recycler 뷰 설정
-//    fun settingRecyclerViewChatRoom() {
-//        fragmentChatOnetoOneBinding.apply {
-//            recyclerViewChatGroup.apply {
-//                // 어뎁터 및 레이아웃 매니저 설정
-//                adapter = ChatOnetoOneRecyclerViewAdapter()
-//                layoutManager = LinearLayoutManager(mainActivity)
-//            }
-//        }
-//    }
-
-    // 그룹 채팅(참여 중 탭) Recycler 뷰 어댑터 세팅
-//    inner class ChatOnetoOneRecyclerViewAdapter: RecyclerView.Adapter<ChatOnetoOneRecyclerViewAdapter.ChatOnetoOneViewHolder>(){
-//        inner class ChatOnetoOneViewHolder(rowChatroomFiledBinding: RowChatroomFiledBinding): RecyclerView.ViewHolder(rowChatroomFiledBinding.root){
-//            val rowChatroomFiledBinding: RowChatroomFiledBinding
-//            init {
-//                this.rowChatroomFiledBinding = rowChatroomFiledBinding
-//
-//                this.rowChatroomFiledBinding.root.layoutParams = ViewGroup.LayoutParams(
-//                    ViewGroup.LayoutParams.MATCH_PARENT,
-//                    ViewGroup.LayoutParams.WRAP_CONTENT
-//                )
-//            }
-//        }
-//
-//        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChatOnetoOneViewHolder {
-//            val rowChatroomFiledBinding = RowChatroomFiledBinding.inflate(layoutInflater)
-//            val chatOnetoOneViewHolder = ChatOnetoOneViewHolder(rowChatroomFiledBinding)
-//
-//            return chatOnetoOneViewHolder
-//        }
-//
-//        override fun getItemCount(): Int {
-//            return 2
-//        }
-//
-//        override fun onBindViewHolder(holder: ChatOnetoOneViewHolder, position: Int) {
-//            holder.rowChatroomFiledBinding.root.setOnClickListener {
-//                mainActivity.replaceFragment(MainFragmentName.CHAT_ROOM, true, true, null)
-//            }
-//
-//            holder.rowChatroomFiledBinding.textViewRowChatroomFiledRoomTitle.text = "홍길동"
-//        }
-//    }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatRoomFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatRoomFragment.kt
@@ -13,7 +13,6 @@ import android.view.ViewGroup
 import android.widget.PopupMenu
 import androidx.recyclerview.widget.LinearLayoutManager
 import kr.co.lion.modigm.R
-import kr.co.lion.modigm.databinding.FragmentChatBinding
 import kr.co.lion.modigm.databinding.FragmentChatRoomBinding
 import kr.co.lion.modigm.ui.MainActivity
 import kr.co.lion.modigm.ui.chat.adapter.MessageAdapter
@@ -36,10 +35,26 @@ class ChatRoomFragment : Fragment() {
     private val messages = mutableListOf<Message>()
     private val userId = "currentUser" // 현재 사용자의 ID를 설정하세요
 
+    // 현재 방 번호, 제목, 그룹 채팅방 여부
+    var chatIdx = 0
+    var chatTitle = "채팅방 제목"
+    var chatMemberList = listOf<String>()
+    var isGroupChat = false
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 
         fragmentChatRoomBinding = FragmentChatRoomBinding.inflate(layoutInflater)
         mainActivity = activity as MainActivity
+
+        // Bundle로부터 데이터 가져오기
+        arguments?.let {
+            chatIdx = it.getInt("chatIdx")
+            chatTitle = it.getString("chatTitle").toString()
+            chatMemberList = it.getStringArrayList("chatMemberList")!!
+            isGroupChat = it.getBoolean("isGroupChat")
+            Log.d("test1234", "채팅방 번호, 이름, 그룹챗 여부 - ${chatIdx}, ${chatTitle}, ${isGroupChat}")
+            Log.d("test1234", "멤버 리스트 - $chatMemberList")
+        }
 
         // 채팅 방 - (툴바) 세팅
         settingToolbar()
@@ -60,6 +75,7 @@ class ChatRoomFragment : Fragment() {
     fun settingToolbar() {
         fragmentChatRoomBinding.apply {
             toolbarChatRoom.apply {
+                title = "$chatTitle"
                 // 왼쪽 네비게이션 버튼(Back)
                 setNavigationOnClickListener {
                     mainActivity.removeFragment(FragmentName.CHAT_ROOM)
@@ -115,11 +131,41 @@ class ChatRoomFragment : Fragment() {
 
     // 테스트 메시지 추가 - (DB 연동하면 나중에 삭제해야함)
     private fun addTestMessages() {
-        messages.add(Message(userId = userId, text = "안녕하세요~", timestamp = "00:01", senderName = "김원빈"))
-        messages.add(Message(userId = "sonUser", text = "안녕하세요!", timestamp = "00:03", senderName = "손흥민"))
-        messages.add(Message(userId = userId, text = "테스트 어때요?", timestamp = "01:04", senderName = "김원빈"))
-        messages.add(Message(userId = "iuUser", text = "테스트 잘 되는거 같네요..?", timestamp = "02:13", senderName = "아이유"))
-        messages.add(Message(userId = "ryuUser", text = "혹시 OOO님도 채팅 한번 쳐주세요!", timestamp = "02:21", senderName = "류현진"))
+        // 그룹 채팅방
+        if (isGroupChat == true) {
+            if (chatIdx % 2 == 0) {
+                messages.add(Message(userId = userId, text = "안녕하세요~", timestamp = "00:01", senderName = "김원빈"))
+                messages.add(Message(userId = chatMemberList[1], text = "안녕하세요!", timestamp = "00:03", senderName = "손흥민"))
+                messages.add(Message(userId = userId, text = "테스트 어때요?", timestamp = "01:04", senderName = "김원빈"))
+                messages.add(Message(userId = chatMemberList[2], text = "테스트 잘 되는거 같네요..?", timestamp = "02:13", senderName = "아이유"))
+                messages.add(Message(userId = chatMemberList[3], text = "혹시 OOO님도 채팅 한번 쳐주세요!", timestamp = "02:21", senderName = "류현진"))
+            }
+            else
+            {
+                messages.add(Message(userId = chatMemberList[1], text = "안녕하세요!", timestamp = "01:11", senderName = "주성원"))
+                messages.add(Message(userId = userId, text = "안녕하세요~", timestamp = "01:13", senderName = "김원빈"))
+                messages.add(Message(userId = chatMemberList[2], text = "안녕하세요!", timestamp = "01:17", senderName = "문태진"))
+                messages.add(Message(userId = chatMemberList[3], text = "반갑습니다~!", timestamp = "01:21", senderName = "전희원"))
+                messages.add(Message(userId = chatMemberList[4], text = "안녕하세요!", timestamp = "01:22", senderName = "엄민식"))
+                messages.add(Message(userId = chatMemberList[5], text = "반갑습니다~!", timestamp = "01:36", senderName = "이승현"))
+            }
+        }
+        // 1:1 채팅방
+        else {
+            if (chatIdx % 2 == 0) {
+                messages.add(Message(userId = userId, text = "안녕하세요~", timestamp = "00:01", senderName = "김원빈"))
+                messages.add(Message(userId = chatMemberList[1], text = "안녕하세요!", timestamp = "00:03", senderName = chatTitle))
+                messages.add(Message(userId = userId, text = "여기 1:1 대화방이죠??", timestamp = "01:04", senderName = "김원빈"))
+                messages.add(Message(userId = chatMemberList[1], text = "네 맞아요!!", timestamp = "02:13", senderName = chatTitle))
+                messages.add(Message(userId = chatMemberList[1], text = "좋네요~", timestamp = "02:21", senderName = chatTitle))
+            }
+            else {
+                messages.add(Message(userId = userId, text = "안녕하세요~", timestamp = "22:48", senderName = "김원빈"))
+                messages.add(Message(userId = userId, text = "모우다임 어플을 처음 이용해 보는데.. 알려주실수 있나요?", timestamp = "22:49", senderName = "김원빈"))
+                messages.add(Message(userId = chatMemberList[1], text = "안녕하세요!", timestamp = "22:59", senderName = chatTitle))
+                messages.add(Message(userId = chatMemberList[1], text = "네 알려드릴게요!! 어떤게 궁금하신가요?", timestamp = "23:00", senderName = chatTitle))
+            }
+        }
 
         // 어댑터에 데이터 변경을 알림
         messageAdapter.notifyDataSetChanged()

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/adapter/ChatRoomAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/adapter/ChatRoomAdapter.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.modigm.ui.chat.adapter
 
+import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -8,6 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.ui.MainActivity
 import kr.co.lion.modigm.ui.chat.ChatRoomItem
+import kr.co.lion.modigm.ui.chat.Message
 import kr.co.lion.modigm.util.FragmentName
 
 class ChatRoomAdapter(
@@ -31,6 +33,8 @@ class ChatRoomAdapter(
 
     inner class ChatRoomViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val roomTitleTextView: TextView = itemView.findViewById(R.id.textViewRowChatroomFiledRoomTitle)
+        private val roomLastTextView: TextView = itemView.findViewById(R.id.textViewRowChatroomFiledLastMessage)
+        private val roomTimeTextView: TextView = itemView.findViewById(R.id.textViewRowChatroomFiledTime)
 
         init {
             itemView.setOnClickListener {
@@ -38,13 +42,47 @@ class ChatRoomAdapter(
                 if (position != RecyclerView.NO_POSITION) {
                     val room = roomList[position]
                     onItemClick(room)
-                    mainActivity.replaceFragment(FragmentName.CHAT_ROOM, true, true, null)
+
+                    // ChatRoomFragment로 데이터 전달
+                    val bundle = Bundle().apply {
+                        putInt("chatIdx", room.chatIdx)
+                        putString("chatTitle", room.chatTitle)
+                        putStringArrayList("chatMemberList", ArrayList(room.chatMemberList))
+                        putInt("participantCount", room.participantCount)
+                        putBoolean("isGroupChat", room.isGroupChat)
+                    }
+                    mainActivity.replaceFragment(FragmentName.CHAT_ROOM, true, true, bundle)
                 }
             }
         }
 
         fun bind(room: ChatRoomItem) {
+            val position = adapterPosition
+            val rooms = roomList[position]
             roomTitleTextView.text = room.chatTitle
+            // Messages DB 가져와서 룸 인덱스 번호의 맨 마지막 내용, 마지막 대화 시간
+            // 아래 내용 다 지워야 함 임시임
+            if (rooms.isGroupChat == true) {
+                if (rooms.chatIdx % 2 == 0) {
+                    roomLastTextView.text = "혹시 OOO님도 채팅 한번 쳐주세요!"
+                    roomTimeTextView.text = "02:21"
+                }
+                else {
+                    roomLastTextView.text = "반갑습니다~!"
+                    roomTimeTextView.text = "01:36"
+                }
+            }
+            else {
+                if (rooms.chatIdx % 2 == 0) {
+                    roomLastTextView.text = "좋네요~"
+                    roomTimeTextView.text = "02:21"
+                }
+                else {
+                    roomLastTextView.text = "네 알려드릴게요!! 어떤게 궁금하신가요?"
+                    roomTimeTextView.text = "23:00"
+                }
+            }
+
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#### #45 : ChatRoom 채팅방, 대화내용 (Group, 1:1) 분리

## 📝 작업 내용
#### 상단 탭(단체 채팅 방 및 1:1 채팅)에 따라 구별되게 채팅 방을 보여줌
#### bundle을 통해 입장한 채팅 방에 맞는 제목으로 설정

## 🗂 스크린샷
![screen](https://github.com/APP-Android2/FinalProject-modigm/assets/103239379/57721f03-0fc3-4162-ae3c-4d6684522fa4)
![22](https://github.com/APP-Android2/FinalProject-modigm/assets/103239379/fef44706-126e-463e-bc52-785786f4980c)

## 💬 리뷰 요구사항
- (Group, 1:1) 채팅 방에 따라 맞게 보여지도록 하였습니다. 채팅 방으로 입장 하면 채팅 방 제목으로 잘 적용됩니다.
- 따로 고쳐야 할 부분 없으면 오늘(목요일)내로 Merge 해두겠습니다!