### PR TITLE
[Feature #67] 글 상세 게시글 수정 화면 구현

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/MainActivity.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/MainActivity.kt
@@ -12,6 +12,7 @@ import kr.co.lion.modigm.ui.chat.ChatFragment
 import kr.co.lion.modigm.ui.chat.ChatGroupFragment
 import kr.co.lion.modigm.ui.chat.ChatOnetoOneFragment
 import kr.co.lion.modigm.ui.chat.ChatRoomFragment
+import kr.co.lion.modigm.ui.detail.DetailEditFragment
 import kr.co.lion.modigm.ui.detail.DetailFragment
 import kr.co.lion.modigm.ui.detail.DetailMemberFragment
 import kr.co.lion.modigm.ui.join.JoinDuplicateFragment
@@ -20,11 +21,8 @@ import kr.co.lion.modigm.ui.like.LikeFragment
 import kr.co.lion.modigm.ui.login.LoginFragment
 import kr.co.lion.modigm.ui.login.OtherLoginFragment
 import kr.co.lion.modigm.ui.profile.ProfileFragment
-<<<<<<< HEAD
 import kr.co.lion.modigm.ui.profile.SettingsFragment
-=======
 import kr.co.lion.modigm.ui.study.FilterSortFragment
->>>>>>> origin/develop
 import kr.co.lion.modigm.ui.study.StudyFragment
 import kr.co.lion.modigm.ui.write.WriteFragment
 import kr.co.lion.modigm.util.FragmentName
@@ -72,6 +70,7 @@ class MainActivity : AppCompatActivity() {
             // 글 상세보기
             FragmentName.DETAIL -> DetailFragment()
             FragmentName.DETAIL_MEMBER -> DetailMemberFragment()
+            FragmentName.DETAIL_EDIT -> DetailEditFragment()
 
             // 회원가입
             FragmentName.JOIN -> JoinFragment()

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailEditFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailEditFragment.kt
@@ -1,0 +1,272 @@
+package kr.co.lion.modigm.ui.detail
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.os.Bundle
+import android.util.TypedValue
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.core.view.children
+import com.google.android.material.chip.Chip
+import com.google.android.material.chip.ChipGroup
+import com.google.android.material.snackbar.Snackbar
+import kr.co.lion.modigm.R
+import kr.co.lion.modigm.databinding.FragmentDetailEditBinding
+import kr.co.lion.modigm.ui.MainActivity
+import kr.co.lion.modigm.util.FragmentName
+
+
+class DetailEditFragment : Fragment() {
+
+    lateinit var fragmentDetailEditBinding: FragmentDetailEditBinding
+
+    lateinit var mainActivity: MainActivity
+
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+        fragmentDetailEditBinding = FragmentDetailEditBinding.inflate(inflater, container, false)
+        mainActivity = activity as MainActivity
+
+        return fragmentDetailEditBinding.root
+    }
+
+    // 뷰가 생성된 직후 호출
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        settingToolbar()
+//        setupBottomSheet()
+        setupButton()
+        setupChipGroups()
+        preselectChips()
+    }
+    // 툴바 설정
+    fun settingToolbar() {
+        fragmentDetailEditBinding.apply {
+            toolBarDetailEdit.apply {
+                title="게시글 수정"
+                //네비게이션
+                setNavigationIcon(R.drawable.icon_arrow_back_24px)
+                setNavigationOnClickListener {
+                    mainActivity.removeFragment(FragmentName.DETAIL_EDIT)
+                }
+            }
+        }
+    }
+
+    // 칩 그룹 설정
+    fun setupChipGroups() {
+        setupChipGroup(
+            fragmentDetailEditBinding.chipGroupDetailEditType,
+            listOf("스터디", "공모전", "프로젝트")
+        )
+
+        setupChipGroup(
+            fragmentDetailEditBinding.chipGroupDetailEditPlace,
+            listOf("오프라인", "온라인", "온·오프 혼합")
+        )
+
+        setupChipGroup(
+            fragmentDetailEditBinding.chipGroupDetailEditApply,
+            listOf("신청제", "선착순")
+        )
+
+        // 장소선택 가시성 설정
+        setPlaceSelectionListener()
+    }
+
+    // 장소 선택에 따른 UI 가시성 조절
+    fun setPlaceSelectionListener() {
+        // 반복하며 칩에 클릭 리스너 설정
+        fragmentDetailEditBinding.chipGroupDetailEditPlace.children.forEach { view ->
+            (view as Chip).setOnClickListener {
+                // 칩 클릭시 가시성 업데이트 함수 호출
+                updatePlaceVisibility(view)
+                // 칩 스타일 업데이트
+                updateChipStyles(fragmentDetailEditBinding.chipGroupDetailEditPlace, view.id)
+            }
+        }
+    }
+
+    // 가시성 업데이트
+    fun updatePlaceVisibility(chip: Chip) {
+        when (chip.text.toString()) {
+            // '온라인'이 선택된 경우 장소 선택 입력 필드 숨김
+            "온라인" -> fragmentDetailEditBinding.textInputLayoutDetailEditPlace.visibility = View.GONE
+            else -> fragmentDetailEditBinding.textInputLayoutDetailEditPlace.visibility = View.VISIBLE
+        }
+    }
+
+    // 칩 스타일 업데이트
+    fun updateChipStyles(group: ChipGroup, checkedId: Int) {
+        group.children.forEach { view ->
+            if (view is Chip) {
+                // 현재 칩이 선택된 상태인지 확인
+                val isSelected = view.id == checkedId
+                // 선택된 칩의 스타일 업데이트
+                updateChipStyle(view, isSelected)
+            }
+        }
+    }
+
+    // 각 그룹에 칩 추가
+    fun setupChipGroup(chipGroup: ChipGroup, chipNames: List<String>) {
+        chipGroup.isSingleSelection = true  // Single selection 모드 활성화
+
+        chipNames.forEach { name ->
+            val chip = Chip(context).apply {
+                text = name
+                id = View.generateViewId()  // 동적으로 ID 생성
+                isClickable = true
+                isCheckable = true
+                chipBackgroundColor =
+                    ColorStateList.valueOf(ContextCompat.getColor(context, R.color.white))
+                setTextColor(ContextCompat.getColor(context, R.color.black))
+                setTextAppearance(R.style.ChipTextStyle)
+            }
+            // 칩을 칩그룹에 추가
+            chipGroup.addView(chip)
+            setupChipListener(chip, chipGroup)
+        }
+    }
+
+    // 개별 칩에 클릭리스너 설정
+    fun setupChipListener(chip: Chip, chipGroup: ChipGroup) {
+        chip.setOnClickListener {
+            // 클릭된 칩이 현재 선택되지 않았다면, 선택 처리
+            if (!chip.isChecked) {
+                // 모든 칩의 선택 상태를 해제하고, 클릭된 칩만 선택
+                chipGroup.children.forEach { view ->
+                    (view as? Chip)?.isChecked = false
+                }
+                // 클릭된 칩을 선택 상태로 설정
+                chip.isChecked = true
+            }
+            // 칩 스타일 업데이트
+            chipGroup.children.forEach { view ->
+                if (view is Chip) {
+                    updateChipStyle(view, view.isChecked)
+                }
+            }
+        }
+    }
+
+    // 칩 스타일 업데이트
+    fun updateChipStyle(chip: Chip, isSelected: Boolean) {
+        val context = chip.context
+        val backgroundColor = if (isSelected) ContextCompat.getColor(
+            context,
+            R.color.pointColor
+        ) else ContextCompat.getColor(context, R.color.white)
+        val textColor = if (isSelected) ContextCompat.getColor(
+            context,
+            R.color.white
+        ) else ContextCompat.getColor(context, R.color.black)
+
+        chip.chipBackgroundColor = ColorStateList.valueOf(backgroundColor)
+        chip.setTextColor(textColor)
+    }
+
+//    fun setupBottomSheet() {
+//        fragmentDetailEditBinding.textInputLayoutDetailEditSkill.editText?.setOnClickListener {
+//            // bottom sheet
+//            val bottomSheet = DetailSkillBottomSheetFragment()
+//            bottomSheet.show(childFragmentManager, bottomSheet.tag)
+//        }
+//
+//    }
+
+    fun setupButton() {
+        fragmentDetailEditBinding.buttonDetailEditDone.setOnClickListener {
+            if (validateInputs()) {
+                // 모든 입력이 유효한 경우 데이터 저장 또는 처리
+                saveData()
+            }
+        }
+    }
+
+    fun saveData() {
+
+        val snackbar =
+            Snackbar.make(fragmentDetailEditBinding.root, "수정되었습니다", Snackbar.LENGTH_LONG)
+
+        // 스낵바의 뷰를 가져옵니다.
+        val snackbarView = snackbar.view
+
+        // 스낵바 텍스트 뷰 찾기
+        val textView =
+            snackbarView.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
+
+        // 텍스트 크기를 dp 단위로 설정
+        val textSizeInPx = dpToPx(requireContext(), 16f)
+        textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeInPx)
+
+        snackbar.show()
+    }
+
+    // 스낵바 글시 크기 설정을 위해 dp를 px로 변환
+    fun dpToPx(context: Context, dp: Float): Float {
+        return dp * context.resources.displayMetrics.density
+    }
+
+    // 입력 유효성 검사
+    fun validateInputs(): Boolean {
+        val title = fragmentDetailEditBinding.editTextDetailEditTitle.text.toString()
+        val description = fragmentDetailEditBinding.editTextDetailEditContext.text.toString()
+
+        // 제목이 비어있거나 너무 짧은 경우 검사
+        if (title.isEmpty() || title.length < 8) {
+            fragmentDetailEditBinding.textInputLayoutDetailEditTitle.error = "제목은 최소 8자 이상이어야 합니다."
+            return false
+        } else {
+            fragmentDetailEditBinding.textInputLayoutDetailEditTitle.error = null
+        }
+
+        // 소개글이 비어있거나 너무 짧은 경우 검사
+        if (description.isEmpty() || description.length < 10) {
+            fragmentDetailEditBinding.textInputLayoutDetailEditContext.error =
+                "소개글은 최소 10자 이상이어야 합니다."
+            return false
+        } else {
+            fragmentDetailEditBinding.textInputLayoutDetailEditContext.error = null
+        }
+
+        return true
+    }
+
+    // 사용자가 이전에 선택한 내용 선택(나중에 DB에서가져올 예정)
+    fun preselectChips() {
+        // '스터디' 칩을 선택하고 스타일을 업데이트합니다.
+        findChipByText(fragmentDetailEditBinding.chipGroupDetailEditType, "스터디")?.let {
+            it.isChecked = true
+            updateChipStyle(it, true)
+        }
+
+        // '온라인' 칩을 선택하고 스타일을 업데이트하며, 관련 UI 가시성도 설정합니다.
+        findChipByText(fragmentDetailEditBinding.chipGroupDetailEditPlace, "온라인")?.let {
+            it.isChecked = true
+            updateChipStyle(it, true)
+            updatePlaceVisibility(it)  // 이 함수를 호출하여 '온라인' 선택 시 관련 UI를 숨깁니다.
+        }
+
+        // '신청제' 칩을 선택하고 스타일을 업데이트합니다.
+        findChipByText(fragmentDetailEditBinding.chipGroupDetailEditApply, "신청제")?.let {
+            it.isChecked = true
+            updateChipStyle(it, true)
+        }
+    }
+
+    // 특정 텍스트를 가진 칩을 찾는 함수
+    fun findChipByText(chipGroup: ChipGroup, text: String): Chip? {
+        // 해당 텍스트를 가진 첫 번째 칩 반환, 없으면 null 반환
+        return chipGroup.children.firstOrNull { (it as Chip).text == text } as? Chip
+    }
+
+}

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -159,15 +159,21 @@ class DetailFragment : Fragment() {
 
 
         // 각 메뉴 아이템에 대한 클릭 리스너 설정
+        // 멤버목록
         popupView.findViewById<TextView>(R.id.menuItem1).setOnClickListener {
             // 화면이동 로직 추가
             mainActivity.replaceFragment(FragmentName.DETAIL_MEMBER, true, false, null)
             popupWindow.dismiss()
         }
+
+        // 글 편집
         popupView.findViewById<TextView>(R.id.menuItem2).setOnClickListener {
             // 화면이동 로직 추가
+            mainActivity.replaceFragment(FragmentName.DETAIL_EDIT, true,false,null)
             popupWindow.dismiss()
         }
+
+        // 글 삭제
         popupView.findViewById<TextView>(R.id.menuItem3).setOnClickListener {
             // 화면이동 로직 추가
             popupWindow.dismiss()

--- a/app/src/main/java/kr/co/lion/modigm/util/FragmentName.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/FragmentName.kt
@@ -15,6 +15,7 @@ enum class FragmentName (var str: String){
     // 글 상세보기
     DETAIL("DetailFragment"),
     DETAIL_MEMBER("DetailMemberFragment"),
+    DETAIL_EDIT("DetailEditFragment"),
 
 
     // 회원가입

--- a/app/src/main/res/layout/fragment_detail_edit.xml
+++ b/app/src/main/res/layout/fragment_detail_edit.xml
@@ -18,9 +18,9 @@
             android:theme="?attr/actionBarTheme"
             app:titleTextAppearance="@style/toolbarText" />
 
-        <!--    <com.google.android.material.divider.MaterialDivider-->
-        <!--        android:layout_width="match_parent"-->
-        <!--        android:layout_height="0.5dp"/>-->
+            <com.google.android.material.divider.MaterialDivider
+                android:layout_width="match_parent"
+                android:layout_height="0.5dp"/>
 
         <ScrollView
             android:layout_width="match_parent"
@@ -71,7 +71,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:hint="제목 입력"
-                        android:inputType="text|textEmailAddress"
+                        android:inputType="text"
                         android:textSize="16dp" />
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -95,10 +95,10 @@
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/editTextDetailEditContext"
                         android:layout_width="match_parent"
-                        android:layout_height="100dp"
+                        android:layout_height="200dp"
                         android:gravity="top"
                         android:hint="소개글 입력(최대한 자세히 입력해주세요)"
-                        android:inputType="text|textEmailAddress"
+                        android:inputType="textMultiLine"
                         android:textSize="16dp" />
                 </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/fragment_detail_edit.xml
+++ b/app/src/main/res/layout/fragment_detail_edit.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        tools:context=".ui.detail.DetailEditFragment">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolBarDetailEdit"
+            style="@style/CustomToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize"
+            android:theme="?attr/actionBarTheme"
+            app:titleTextAppearance="@style/toolbarText" />
+
+        <!--    <com.google.android.material.divider.MaterialDivider-->
+        <!--        android:layout_width="match_parent"-->
+        <!--        android:layout_height="0.5dp"/>-->
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:paddingHorizontal="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="어떤 활동을 하고 싶으신가요?"
+                    android:textSize="18dp"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.chip.ChipGroup
+                    android:id="@+id/chipGroupDetailEditType"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    app:singleLine="true"
+                    app:singleSelection="true" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="모집 소개글을 작성해주세요"
+                    android:textSize="18dp"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/textInputLayoutDetailEditTitle"
+                    style="@style/CustomTextInputLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="14dp"
+                    app:endIconMode="clear_text"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="false">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editTextDetailEditTitle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="제목 입력"
+                        android:inputType="text|textEmailAddress"
+                        android:textSize="16dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="ex.개발자 북클럽 모집(최소 8자 이상)"
+                    android:textColor="@color/textGray"
+                    android:textSize="14dp" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/textInputLayoutDetailEditContext"
+                    style="@style/CustomTextInputLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    app:endIconMode="clear_text"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="false">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editTextDetailEditContext"
+                        android:layout_width="match_parent"
+                        android:layout_height="100dp"
+                        android:gravity="top"
+                        android:hint="소개글 입력(최대한 자세히 입력해주세요)"
+                        android:inputType="text|textEmailAddress"
+                        android:textSize="16dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:text="작성 예시보기"
+                    android:textColor="@color/pointColor"
+                    android:textSize="14dp" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="진행할 장소를 입력해주세요"
+                    android:textSize="18dp"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.chip.ChipGroup
+                    android:id="@+id/chipGroupDetailEditPlace"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    app:singleLine="true"
+                    app:singleSelection="true" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/textInputLayoutDetailEditPlace"
+                    style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    app:endIconMode="clear_text"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="false"
+                    app:startIconDrawable="@drawable/icon_location_on_24px">
+
+                    <AutoCompleteTextView
+                        android:id="@+id/editTextDetailEditTitleLocation"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:focusable="false"
+                        android:inputType="none"
+                        android:text="장소를 입력해주세요"
+                        android:textSize="16dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="신청 방식을 선택해주세요"
+                    android:textSize="18dp"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.chip.ChipGroup
+                    android:id="@+id/chipGroupDetailEditApply"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    app:singleLine="true"
+                    app:singleSelection="true" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:paddingBottom="20dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="20dp"
+                        android:text="스터디 진행에 필요한 기술 스텍을 선택해주세요"
+                        android:textSize="18dp"
+                        android:textStyle="bold" />
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/textInputLayoutDetailEditSkill"
+                        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="14dp"
+                        app:endIconMode="clear_text"
+                        app:hintAnimationEnabled="false"
+                        app:hintEnabled="false">
+
+                        <AutoCompleteTextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:drawableRight="@drawable/icon_expand_more_24px"
+                            android:focusable="false"
+                            android:inputType="none"
+                            android:text="필요한 기술 선택"
+                            android:textSize="16dp" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+
+                    <com.google.android.material.chip.ChipGroup
+                        android:id="@+id/ChipGroupDetailEdit"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
+                </LinearLayout>
+
+                <Button
+                    android:id="@+id/buttonDetailEditDone"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="10dp"
+                    android:onClick="setupButton"
+                    android:text="저장"
+                    android:textSize="16dp" />
+            </LinearLayout>
+        </ScrollView>
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -31,4 +31,27 @@
         <item name="android:textSize">16dp</item>
     </style>
 
+    <!-- Chip의 텍스트 스타일 -->
+    <style name="ChipTextStyle" parent="">
+        <item name="android:textSize">16dp</item>
+    </style>
+
+
+    <style name="CustomButtonStyle" parent="Widget.MaterialComponents.Button">
+        <item name="backgroundTint">@color/pointColor</item>
+        <item name="android:textColor">@color/white</item>
+        <item name="android:padding">10dp</item>
+        <item name="cornerRadius">50dp</item>
+    </style>
+
+    <style name="CustomTextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+        <!-- Error text appearance -->
+        <item name="errorTextAppearance">@style/ErrorTextAppearance</item>
+    </style>
+
+    <style name="ErrorTextAppearance" parent="TextAppearance.AppCompat">
+        <item name="android:textSize">14dp</item> <!-- 원하는 크기로 설정 -->
+        <item name="android:textColor">@color/design_default_color_error</item> <!-- 원하는 색상으로 설정 -->
+    </style>
+
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #67 

## 📝작업 내용

> 글 수정 화면 구현했습니다 
규모가 그리 안클거라 생각하고 바텀 시트까지 작업하다가 pr단위가 너무 커지는거 같아서 바텀시트 따로 pr날리겠습니다 

### 스크린샷 (선택)
| 글 수정 화면 | 유효성 검사 |
|--|--|
<image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/961970f2-836e-4556-b038-9a83afe3b83f" width=250 /> | <image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/817daba7-12c5-4160-b42f-f132b95d2964" width=250 />| 

|장소선택(온라인) | 장소선택 (오프라인)|
|--|--|
<image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/7a691d13-695d-4ed9-9d49-d1bd3a290ee8" width=250 /> |<image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/c5b4cd32-94b1-40e7-9edf-b72fa2614566" width=250 /> | 

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 툴바 title 과 툴바 구분선의 유무
> 유효성 검사를 한번에 할지 아님 스크린 샷처럼 하나씩 할지'
> 소개글 입력 칸의 크기(뭔가 넘 작은거 같아서 한 두배정도로 늘릴까 하는데 어떨까요)

