### PR TITLE
[#77] feature - 채팅 하단 바 설정 및 채팅방 나가기 기능

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/model/ChatRoomData.kt
+++ b/app/src/main/java/kr/co/lion/modigm/model/ChatRoomData.kt
@@ -3,6 +3,7 @@ package kr.co.lion.modigm.model
 data class ChatRoomData(
     val chatIdx: Int = 0, // 채팅방 고유 ID
     val chatTitle: String = "", // 채팅방 이름
+    val chatRoomImage: String = "",
     val chatMemberList: List<String> = listOf(), // 채팅방 참여 멤버 UID 목록
     val participantCount: Int = 2, // 최소 참여자 수 2 (그룹 채팅방일 때만 해당)
     val groupChat: Boolean = false, // 그룹 채팅방 여부
@@ -12,5 +13,5 @@ data class ChatRoomData(
     val lastReadTimestamp: Map<String, Long> = mutableMapOf("1" to 0L), // 각 참여자의 마지막으로 읽은 메시지의 타임스탬프
     var unreadMessageCount: Int = 0 // 안 읽은 메시지 개수를 추적하는 필드
 ) {
-    constructor(): this(0,"", listOf(), 2, false, "", 0, "", mutableMapOf("1" to 0L), 0)
+    constructor(): this(0,"", "", listOf(), 2, false, "", 0, "", mutableMapOf("1" to 0L), 0)
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatFragment.kt
@@ -144,6 +144,7 @@ class ChatFragment : Fragment() {
 
             val chatIdx = chatRoomSequence + 1
             val chatTitle = "제 13회 해커톤 준비"
+            val chatRoomImage = ""
             val chatMemberList = listOf("currentUser", "sonUser", "iuUser", "ryuUser")
             val participantCount = 4
             val groupChat = true
@@ -151,7 +152,7 @@ class ChatFragment : Fragment() {
             val lastChatFullTime = 0L
             val lastChatTime = "00:00"
 
-            val chatRoomData = ChatRoomData(chatIdx, chatTitle, chatMemberList, participantCount, groupChat, lastChatMessage, lastChatFullTime, lastChatTime)
+            val chatRoomData = ChatRoomData(chatIdx, chatTitle, chatRoomImage, chatMemberList, participantCount, groupChat, lastChatMessage, lastChatFullTime, lastChatTime)
 
             // 채팅 방 생성
             ChatRoomDao.insertChatRoomData(chatRoomData)

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatFragment.kt
@@ -70,27 +70,24 @@ class ChatFragment : Fragment() {
 
     // 하단 바 홈으로 체크 표시 설정
     fun settingBottomTabs() {
-        /*
         fragmentChatBinding.apply {
-            val menuItemId = R.id.main_bottom_navi_chat
+            val menuItemId = R.id.bottomNaviChat
             fragmentChatBinding.mainBottomNavi.menu.findItem(menuItemId)?.isChecked = true
         }
-        */
     }
 
     // 하단 바 클릭 설정
     fun bottomSheetSetting() {
-        /*
         fragmentChatBinding.apply {
             mainBottomNavi.setOnItemSelectedListener { item ->
                 when(item.itemId) {
-                    R.id.main_bottom_navi_study -> {
+                    R.id.bottomNaviStudy -> {
                         mainActivity.replaceFragment(FragmentName.STUDY, false, false, null)
                     }
-                    R.id.main_bottom_navi_like -> {
+                    R.id.bottomNaviHeart -> {
                         mainActivity.replaceFragment(FragmentName.LIKE, false, false, null)
                     }
-                    R.id.main_bottom_navi_chat -> {
+                    R.id.bottomNaviChat -> {
                         mainActivity.replaceFragment(FragmentName.CHAT, false, false, null)
                     }
                     else -> {
@@ -100,7 +97,6 @@ class ChatFragment : Fragment() {
                 true
             }
         }
-        */
     }
 
     // ViewPager 설정

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatFragment.kt
@@ -46,8 +46,10 @@ class ChatFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         // 하단 바 체크 설정(채팅에 체크) 및 하단 바 이동 설정
+        /*
         settingBottomTabs()
         bottomSheetSetting()
+        */
 
         // 채팅 - (ViewPager) 세팅
         viewPagerActiviation()
@@ -69,6 +71,7 @@ class ChatFragment : Fragment() {
     }
 
     // 하단 바 홈으로 체크 표시 설정
+    /*
     fun settingBottomTabs() {
         fragmentChatBinding.apply {
             val menuItemId = R.id.bottomNaviChat
@@ -98,6 +101,7 @@ class ChatFragment : Fragment() {
             }
         }
     }
+    */
 
     // ViewPager 설정
     private fun viewPagerActiviation(){

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatGroupFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatGroupFragment.kt
@@ -68,7 +68,7 @@ class ChatGroupFragment : Fragment() {
     fun gettingGroupChatRoomData() {
         CoroutineScope(Dispatchers.Main).launch {
             // 대화방 목록 데이터 가져오기
-            val newChatRoomDataList = ChatRoomDao.getGroupChatRooms()
+            val newChatRoomDataList = ChatRoomDao.getGroupChatRooms("currentUser")
 
             // 새로운 목록으로 업데이트
             chatRoomDataList.clear()

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatOnetoOneFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatOnetoOneFragment.kt
@@ -66,7 +66,7 @@ class ChatOnetoOneFragment : Fragment() {
     fun gettingOneToOneChatRoomData() {
         CoroutineScope(Dispatchers.Main).launch {
             // 대화방 목록 데이터 가져오기
-            val newChatRoomDataList = ChatRoomDao.getOneToOneChatRooms()
+            val newChatRoomDataList = ChatRoomDao.getOneToOneChatRooms("currentUser")
 
             // 새로운 목록으로 업데이트
             chatRoomDataList.clear()

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatRoomFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatRoomFragment.kt
@@ -66,9 +66,6 @@ class ChatRoomFragment : Fragment() {
             chatTitle = it.getString("chatTitle").toString()
             chatMemberList = it.getStringArrayList("chatMemberList")!!
             isGroupChat = it.getBoolean("groupChat")
-            // Log.d("test1234", "채팅방 번호, 이름, 그룹챗 여부 - ${chatIdx}, ${chatTitle}, ${isGroupChat}")
-            // Log.d("test1234", "멤버 리스트 - $chatMemberList")
-            // Log.d("test1234", "멤버 리스트: ${chatMemberList.size}명")
         }
 
         // 채팅 방 - (툴바) 세팅
@@ -91,18 +88,6 @@ class ChatRoomFragment : Fragment() {
         Log.d("test1234", "ChatRoomFragment - onDestroy")
         chatViewModel.triggerChatRoomDataUpdate()
     }
-
-
-
-//    override fun onAttach(context: Context) {
-//        super.onAttach(context)
-//        mainActivity = context as MainActivity
-//    }
-//
-//    override fun onDestroyView() {
-//        super.onDestroyView()
-//        mainActivity.updateChatFragments() // MainActivity의 콜백 메서드 호출
-//    }
 
     // 툴바 세팅
     fun settingToolbar() {
@@ -137,13 +122,17 @@ class ChatRoomFragment : Fragment() {
             popupMenu.menuInflater.inflate(R.menu.popup_menu_chatroom_more_vert, popupMenu.menu)
             popupMenu.setOnMenuItemClickListener { menuItem ->
                 when (menuItem.itemId) {
+                    // 채팅방 나가기
                     R.id.item1 -> {
+                        outChatRoom()
                         mainActivity.removeFragment(FragmentName.CHAT_ROOM)
                         true
                     }
+                    // 멤버 보기
                     R.id.item2 -> {
                         true
                     }
+                    // 공지
                     R.id.item3 -> {
                         true
                     }
@@ -273,6 +262,13 @@ class ChatRoomFragment : Fragment() {
             } else {
                 imageButtonChatRoomSend.backgroundTintList = ColorStateList.valueOf(Color.parseColor("#1A51C5"))
             }
+        }
+    }
+
+    // 대화방 나가기
+    fun outChatRoom() {
+        CoroutineScope(Dispatchers.Main).launch {
+            ChatRoomDao.removeUserFromChatMemberList(chatIdx, loginUserId)
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/adapter/ChatRoomAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/adapter/ChatRoomAdapter.kt
@@ -1,11 +1,14 @@
 package kr.co.lion.modigm.ui.chat.adapter
 
+import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.model.ChatRoomData
@@ -35,6 +38,7 @@ class ChatRoomAdapter(
         private val roomTitleTextView: TextView = itemView.findViewById(R.id.textViewRowChatroomFiledRoomTitle)
         private val roomLastTextView: TextView = itemView.findViewById(R.id.textViewRowChatroomFiledLastMessage)
         private val roomTimeTextView: TextView = itemView.findViewById(R.id.textViewRowChatroomFiledTime)
+        private val roomImageImageView: ImageView = itemView.findViewById(R.id.imageViewRowChatroomFiledImage)
 
         init {
             itemView.setOnClickListener {
@@ -62,6 +66,24 @@ class ChatRoomAdapter(
             val rooms = roomList[position]
             // 채팅 방 제목
             roomTitleTextView.text = room.chatTitle
+
+            // 프로필 설정(회원 아이디 별 사진으로) (아직 Firebase 정보 없음) - DB 연동해야함
+            if(rooms.groupChat == false){
+                if (rooms.chatMemberList.contains("iuUser")) {
+                    roomImageImageView.setImageResource(R.drawable.test_profile_image_iu)
+                } else if (rooms.chatMemberList.contains("sonUser")) {
+                    roomImageImageView.setImageResource(R.drawable.test_profile_image_son)
+                } else if (rooms.chatMemberList.contains("ryuUser")) {
+                    roomImageImageView.setImageResource(R.drawable.test_profile_image_ryu)
+                } else {
+                    roomImageImageView.setImageResource(R.drawable.test_profile_image)
+                }
+            }
+            // 그룹 채팅 사진은 글 작성 -> 그 이미지로 설정 (아직 Firebase 정보 없음) - DB 연동해야함
+            else {
+                roomImageImageView.setImageResource(R.drawable.test_profile_image)
+            }
+
             if ((room.lastChatMessage).isNotEmpty()) {
                 // 마지막 대화 내용
                 roomLastTextView.text = room.lastChatMessage

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/vm/ChatViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/vm/ChatViewModel.kt
@@ -14,5 +14,4 @@ class ChatViewModel : ViewModel() {
     fun triggerChatRoomDataUpdate() {
         _updateChatRoomData.value = Unit
     }
-
 }

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -59,7 +59,6 @@
                 android:layout_height="0dp"
                 android:layout_weight="1" />
 
-            <!--
             <com.google.android.material.bottomnavigation.BottomNavigationView
                 android:id="@+id/main_bottom_navi"
                 android:layout_width="match_parent"
@@ -71,8 +70,7 @@
                 app:labelVisibilityMode="labeled"
                 app:layout_behavior="@string/hide_bottom_view_on_scroll_behavior"
                 app:layout_insetEdge="bottom"
-                app:menu="@menu/menu_main_bottom_navi" />
-            -->
+                app:menu="@menu/menu_study_bottom_navi" />
         </LinearLayout>
 
     </LinearLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #77 

## 📝작업 내용

채팅 페이지 - 하단 바 추가등록 (클릭 된 하단 바 색상 변경 추가, Fragment 이동 추가)
채팅방 나가기 기능 추가 - Firebase에 ChatRoomData - chatMemberList에서 배열 안에 있는 현재 로그인한 아이디 제거

### 스크린샷 (선택)

![Screen](https://github.com/APP-Android2/FinalProject-modigm/assets/103239379/6424c560-7935-4974-821b-594e27e98af6)

## 💬리뷰 요구사항(선택)

하단 바 Fragment이동, 채팅 방 나가기 정상 작동합니다 추가하거나 변경해야 할 부분이 있다면 말씀해주세요
이상이 없다면 30분 뒤(4시 35분 쯤)에 머지 하도록 하겠습니다!
