### PR TITLE
[#81] feature 스터디 목록 UI 데이터작업

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/db/remote/StudyDataSource.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/remote/StudyDataSource.kt
@@ -1,0 +1,9 @@
+package kr.co.lion.modigm.db.remote
+
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.firestore
+
+class StudyDataSource {
+    private val studyCollection = Firebase.firestore.collection("Study")
+
+}

--- a/app/src/main/java/kr/co/lion/modigm/model/StudyData.kt
+++ b/app/src/main/java/kr/co/lion/modigm/model/StudyData.kt
@@ -1,0 +1,18 @@
+package kr.co.lion.modigm.model
+
+data class StudyData(
+    val studyIdx: Int = -1,
+    val studyTitle: String = "",
+    val studyContent: String = "",
+    val studyType: Int = 0,
+    val studyPeriod: Int = 0,
+    val studyMeet: Int = 0,
+    val studyPlace: String = "",
+    val studyApply: Int = 0,
+    val studySkillList: List<Int> = listOf(),
+    val studyState: Boolean = true,
+    val studyPic: String = "",
+    val studyUserCnt: Int = 0,
+    val studyUidList: List<String> = listOf(),
+    val chatIdx: Int = -1
+)

--- a/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
@@ -1,0 +1,8 @@
+package kr.co.lion.modigm.repository
+
+import kr.co.lion.modigm.db.remote.StudyDataSource
+
+class StudyRepository {
+
+    private val studyDataSource = StudyDataSource()
+}

--- a/app/src/main/java/kr/co/lion/modigm/ui/MainActivity.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/MainActivity.kt
@@ -20,11 +20,8 @@ import kr.co.lion.modigm.ui.like.LikeFragment
 import kr.co.lion.modigm.ui.login.LoginFragment
 import kr.co.lion.modigm.ui.login.OtherLoginFragment
 import kr.co.lion.modigm.ui.profile.ProfileFragment
-<<<<<<< HEAD
 import kr.co.lion.modigm.ui.profile.SettingsFragment
-=======
 import kr.co.lion.modigm.ui.study.FilterSortFragment
->>>>>>> origin/develop
 import kr.co.lion.modigm.ui.study.StudyFragment
 import kr.co.lion.modigm.ui.write.WriteFragment
 import kr.co.lion.modigm.util.FragmentName

--- a/app/src/main/java/kr/co/lion/modigm/ui/MainActivity.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/MainActivity.kt
@@ -21,6 +21,7 @@ import kr.co.lion.modigm.ui.login.LoginFragment
 import kr.co.lion.modigm.ui.login.OtherLoginFragment
 import kr.co.lion.modigm.ui.profile.ProfileFragment
 import kr.co.lion.modigm.ui.profile.SettingsFragment
+import kr.co.lion.modigm.ui.study.BottomNaviFragment
 import kr.co.lion.modigm.ui.study.FilterSortFragment
 import kr.co.lion.modigm.ui.study.StudyFragment
 import kr.co.lion.modigm.ui.write.WriteFragment
@@ -41,7 +42,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         // 채팅 화면 띄우기 (테스트) - 원빈
-        replaceFragment(FragmentName.CHAT, false, false, null)
+        replaceFragment(FragmentName.BOTTOM_NAVI, false, false, null)
 
         // 화면 테스트 - 희원
         // replaceFragment(FragmentName.PROFILE, false, false, null)
@@ -87,6 +88,7 @@ class MainActivity : AppCompatActivity() {
             // 스터디
             FragmentName.STUDY -> StudyFragment()
             FragmentName.FILTER_SORT -> FilterSortFragment()
+            FragmentName.BOTTOM_NAVI -> BottomNaviFragment()
 
 
             // 글 작성

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/BottomNaviFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/BottomNaviFragment.kt
@@ -1,0 +1,84 @@
+package kr.co.lion.modigm.ui.study
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import kr.co.lion.modigm.R
+import kr.co.lion.modigm.databinding.FragmentBottomNaviBinding
+import kr.co.lion.modigm.ui.chat.ChatFragment
+import kr.co.lion.modigm.ui.like.LikeFragment
+import kr.co.lion.modigm.ui.profile.ProfileFragment
+
+
+class BottomNaviFragment : Fragment() {
+
+    private lateinit var binding: FragmentBottomNaviBinding
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        // 바인딩
+        binding = FragmentBottomNaviBinding.inflate(inflater,container,false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initView()
+    }
+
+    fun initView(){
+
+        // 최초 화면이 null 이라면 스터디 목록을 띄운다.
+        if(childFragmentManager.findFragmentById(R.id.bottomNaviContainer) == null){
+            childFragmentManager.beginTransaction()
+                .replace(R.id.bottomNaviContainer, StudyFragment())
+                .commit()
+        }
+
+        // 바인딩
+        with(binding){
+
+            // 바텀 내비게이션
+            with(bottomNavigationView){
+
+                // 아이템 클릭 시 전환 설정
+                setOnItemSelectedListener { item ->
+                    when(item.itemId) {
+
+                        // 스터디 클릭 시
+                        R.id.bottomNaviStudy -> {
+                            childFragmentManager.beginTransaction()
+                                .replace(R.id.bottomNaviContainer, StudyFragment())
+                                .commit()
+                        }
+
+                        // 찜 클릭 시
+                        R.id.bottomNaviHeart -> {
+                            childFragmentManager.beginTransaction()
+                                .replace(R.id.bottomNaviContainer, LikeFragment())
+                                .commit()
+                        }
+
+                        // 채팅 클릭 시
+                        R.id.bottomNaviChat -> {
+                            childFragmentManager.beginTransaction()
+                                .replace(R.id.bottomNaviContainer, ChatFragment())
+                                .commit()
+                        }
+
+                        // 마이 클릭 시
+                        R.id.bottomNaviMy -> {
+                            childFragmentManager.beginTransaction()
+                                .replace(R.id.bottomNaviContainer, ProfileFragment())
+                                .commit()
+                        }
+
+                    }
+                    true
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/StudyAllFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/StudyAllFragment.kt
@@ -9,25 +9,43 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentStudyAllBinding
-import kr.co.lion.modigm.ui.login.OtherLoginFragment
+import kr.co.lion.modigm.ui.detail.DetailFragment
 import kr.co.lion.modigm.ui.study.adapter.StudyAllAdapter
 import kr.co.lion.modigm.ui.study.vm.StudyViewModel
-import kr.co.lion.modigm.util.FragmentName
 
 
 class StudyAllFragment : Fragment() {
 
+    // 바인딩
     private lateinit var binding: FragmentStudyAllBinding
+
+    // 뷰모델
     private val viewModel: StudyViewModel by viewModels()
 
-
+    // 어답터
     val studyAllAdapter: StudyAllAdapter = StudyAllAdapter(
-        rowClickListener = {
+        // 최초 리스트
+        emptyList(),
 
+        // 항목 클릭 시
+        rowClickListener = { studyIdx ->
+
+            // DetailFragment로 이동
+            val detailFragment = DetailFragment().apply {
+                arguments = Bundle().apply {
+                    putInt("studyIdx", studyIdx)
+                }
+            }
+
+            requireActivity().supportFragmentManager.beginTransaction()
+                .replace(R.id.containerMain, detailFragment)
+                .addToBackStack(null) // 뒤로가기 버튼으로 이전 상태로 돌아갈 수 있도록
+                .commit()
         }
     )
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+
 
         // 바인딩
         binding = FragmentStudyAllBinding.inflate(inflater,container,false)
@@ -53,10 +71,7 @@ class StudyAllFragment : Fragment() {
                 // 클릭 시
                 setOnClickListener {
                     // 필터 및 정렬 화면으로 이동
-                    val supportFragmentManager = parentFragmentManager.beginTransaction()
-                    supportFragmentManager.replace(R.id.containerMain, FilterSortFragment())
-                        .addToBackStack(FragmentName.FILTER_SORT.str)
-                        .commit()
+                    requireActivity().supportFragmentManager.beginTransaction().replace(R.id.containerMain, FilterSortFragment()).commit()
                 }
             }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/StudyFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/StudyFragment.kt
@@ -1,29 +1,26 @@
 package kr.co.lion.modigm.ui.study
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.viewpager2.widget.ViewPager2
+import androidx.fragment.app.Fragment
 import com.google.android.material.tabs.TabLayout
-import com.google.android.material.tabs.TabLayoutMediator
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentStudyBinding
-import kr.co.lion.modigm.ui.join.JoinStep1Fragment
-import kr.co.lion.modigm.ui.join.JoinStep2Fragment
-import kr.co.lion.modigm.ui.join.JoinStep3Fragment
-import kr.co.lion.modigm.ui.join.adapter.JoinViewPagerAdapter
-import kr.co.lion.modigm.ui.study.adapter.StudyViewPagerAdapter
+import kr.co.lion.modigm.ui.write.WriteFragment
 
 class StudyFragment : Fragment() {
 
+    // 바인딩
     private lateinit var binding : FragmentStudyBinding
+
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 
         // 바인딩
         binding = FragmentStudyBinding.inflate(inflater,container, false)
+
 
         return binding.root
     }
@@ -40,7 +37,7 @@ class StudyFragment : Fragment() {
 
         // 초기 뷰 세팅
         initView()
-        
+
     }
 
     // 초기 뷰 세팅
@@ -48,6 +45,8 @@ class StudyFragment : Fragment() {
 
         // 바인딩
         with(binding){
+
+            // 탭 레이아웃 설정
             val tabLayout: TabLayout = tabLayoutStudy
 
             // 탭 선택 리스너 설정
@@ -70,10 +69,15 @@ class StudyFragment : Fragment() {
                 override fun onTabReselected(tab: TabLayout.Tab) {
                     // 필요시 구현
                 }
+
             })
 
-
-
+            // FAB 설정
+            with(fabStudyWrite){
+                setOnClickListener{
+                    requireActivity().supportFragmentManager.beginTransaction().replace(R.id.containerMain, WriteFragment()).commit()
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/StudyFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/StudyFragment.kt
@@ -37,7 +37,6 @@ class StudyFragment : Fragment() {
 
         // 초기 뷰 세팅
         initView()
-
     }
 
     // 초기 뷰 세팅

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/StudyMyFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/StudyMyFragment.kt
@@ -9,19 +9,38 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentStudyMyBinding
+import kr.co.lion.modigm.ui.detail.DetailFragment
 import kr.co.lion.modigm.ui.study.adapter.StudyMyAdapter
 import kr.co.lion.modigm.ui.study.vm.StudyViewModel
-import kr.co.lion.modigm.util.FragmentName
 
 
 class StudyMyFragment : Fragment() {
 
+    // 바인딩
     private lateinit var binding: FragmentStudyMyBinding
+
+    // 뷰모델
     private val viewModel: StudyViewModel by viewModels()
 
+    // 어답터
     val studyMyAdapter: StudyMyAdapter = StudyMyAdapter(
-        rowClickListener = {
+        // 최초 리스트
+        emptyList(),
 
+        // 항목 클릭 시
+        rowClickListener = { studyIdx ->
+
+            // DetailFragment로 이동
+            val detailFragment = DetailFragment().apply {
+                arguments = Bundle().apply {
+                    putInt("studyIdx", studyIdx)
+                }
+            }
+
+            requireActivity().supportFragmentManager.beginTransaction()
+                .replace(R.id.containerMain, detailFragment)
+                .addToBackStack(null) // 뒤로가기 버튼으로 이전 상태로 돌아갈 수 있도록
+                .commit()
         }
     )
 
@@ -51,10 +70,7 @@ class StudyMyFragment : Fragment() {
                 // 클릭 시
                 setOnClickListener {
                     // 필터 및 정렬 화면으로 이동
-                    val supportFragmentManager = parentFragmentManager.beginTransaction()
-                    supportFragmentManager.replace(R.id.containerMain, FilterSortFragment())
-                        .addToBackStack(FragmentName.FILTER_SORT.str)
-                        .commit()
+                    requireActivity().supportFragmentManager.beginTransaction().replace(R.id.containerMain, FilterSortFragment()).commit()
                 }
             }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudyAllAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudyAllAdapter.kt
@@ -1,11 +1,14 @@
 package kr.co.lion.modigm.ui.study.adapter
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.modigm.databinding.RowStudyAllBinding
+import kr.co.lion.modigm.model.StudyData
 
 class StudyAllAdapter(
+    private var studyList: List<StudyData>,
     private val rowClickListener: (Int) -> Unit,
 ) : RecyclerView.Adapter<StudyAllViewHolder>() {
     override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): StudyAllViewHolder {
@@ -18,11 +21,17 @@ class StudyAllAdapter(
     }
 
     override fun getItemCount(): Int {
-        return 10
+        return studyList.size
     }
 
     override fun onBindViewHolder(holder: StudyAllViewHolder, position: Int) {
-        holder.bind(rowClickListener)
+        holder.bind(studyList[position],rowClickListener)
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun updateData(list: List<StudyData>) {
+        studyList = list
+        notifyDataSetChanged()
     }
 }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudyAllViewHolder.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudyAllViewHolder.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.RowStudyAllBinding
+import kr.co.lion.modigm.model.StudyData
 
 class StudyAllViewHolder(
     private val binding: RowStudyAllBinding,
@@ -14,7 +15,7 @@ class StudyAllViewHolder(
 
 
     // 전체 스터디 항목별 세팅
-    fun bind(rowClickListener: (Int) -> Unit) {
+    fun bind(studyData: StudyData, rowClickListener: (Int) -> Unit) {
 
         with(binding) {
             // 항목 하나
@@ -27,6 +28,7 @@ class StudyAllViewHolder(
 
                 // 클릭 리스너 설정.
                 setOnClickListener {
+                    rowClickListener.invoke(studyData.studyIdx)
                 }
 
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudyAllViewHolder.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudyAllViewHolder.kt
@@ -1,7 +1,9 @@
 package kr.co.lion.modigm.ui.study.adapter
 
+import android.graphics.Color
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.RowStudyAllBinding
 
 class StudyAllViewHolder(
@@ -26,7 +28,43 @@ class StudyAllViewHolder(
                 // 클릭 리스너 설정.
                 setOnClickListener {
                 }
+
+
+                with(imageViewStudyAllHeart){
+                    setOnClickListener {
+                        toggleLikeButton()
+                    }
+                }
             }
         }
+    }
+
+    // 좋아요 버튼 상태 토글
+    fun toggleLikeButton() {
+        with(binding){
+            with(imageViewStudyAllHeart){
+                val currentIconResId = tag as? Int ?: R.drawable.icon_favorite_24px
+
+                if (currentIconResId == R.drawable.icon_favorite_24px) {
+                    // 좋아요 채워진 아이콘으로 변경
+                    setImageResource(R.drawable.icon_favorite_full_24px)
+                    // 상태 태그 업데이트
+                    tag = R.drawable.icon_favorite_full_24px
+
+                    // 새 색상을 사용하여 틴트 적용
+                    setColorFilter(Color.parseColor("#D73333"))
+
+                } else {
+                    // 기본 아이콘으로 변경
+                    setImageResource(R.drawable.icon_favorite_24px)
+                    // 상태 태그 업데이트
+                    tag = R.drawable.icon_favorite_24px
+
+                    // 틴트 제거 (원래 아이콘 색상으로 복원)
+                    clearColorFilter()
+                }
+            }
+        }
+
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudyMyAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudyMyAdapter.kt
@@ -1,11 +1,14 @@
 package kr.co.lion.modigm.ui.study.adapter
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.modigm.databinding.RowStudyMyBinding
+import kr.co.lion.modigm.model.StudyData
 
 class StudyMyAdapter(
+    private var studyList: List<StudyData>,
     private val rowClickListener: (Int) -> Unit,
 ) : RecyclerView.Adapter<StudyMyViewHolder>() {
     override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): StudyMyViewHolder {
@@ -18,10 +21,16 @@ class StudyMyAdapter(
     }
 
     override fun getItemCount(): Int {
-        return 2
+        return studyList.size
     }
 
     override fun onBindViewHolder(holder: StudyMyViewHolder, position: Int) {
-        holder.bind(rowClickListener)
+        holder.bind(studyList[position],rowClickListener)
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun updateData(list: List<StudyData>) {
+        studyList = list
+        notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudyMyViewHolder.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudyMyViewHolder.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.RowStudyMyBinding
+import kr.co.lion.modigm.model.StudyData
 
 class StudyMyViewHolder(
     private val binding: RowStudyMyBinding,
@@ -14,7 +15,7 @@ class StudyMyViewHolder(
 
 
     // 전체 스터디 항목별 세팅
-    fun bind(rowClickListener: (Int) -> Unit) {
+    fun bind(studyData: StudyData, rowClickListener: (Int) -> Unit) {
 
         with(binding) {
             // 항목 하나
@@ -27,6 +28,7 @@ class StudyMyViewHolder(
 
                 // 클릭 리스너 설정.
                 setOnClickListener {
+                    rowClickListener.invoke(studyData.studyIdx)
                 }
 
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudyMyViewHolder.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudyMyViewHolder.kt
@@ -1,7 +1,9 @@
 package kr.co.lion.modigm.ui.study.adapter
 
+import android.graphics.Color
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.RowStudyMyBinding
 
 class StudyMyViewHolder(
@@ -25,6 +27,35 @@ class StudyMyViewHolder(
 
                 // 클릭 리스너 설정.
                 setOnClickListener {
+                }
+
+
+                // 좋아요 버튼 상태 토글
+                fun toggleLikeButton() {
+                    // 현재 설정된 이미지 리소스 ID를 확인하고 상태를 토글
+                    val currentIconResId = imageViewStudyMyHeart.tag as? Int ?: R.drawable.icon_favorite_24px
+                    if (currentIconResId == R.drawable.icon_favorite_24px) {
+                        // 좋아요 채워진 아이콘으로 변경
+                        imageViewStudyMyHeart.setImageResource(R.drawable.icon_favorite_full_24px)
+                        // 상태 태그 업데이트
+                        imageViewStudyMyHeart.tag = R.drawable.icon_favorite_full_24px
+
+                        // 새 색상을 사용하여 틴트 적용
+                        imageViewStudyMyHeart.setColorFilter(Color.parseColor("#D73333"))
+                    } else {
+                        // 기본 아이콘으로 변경
+                        imageViewStudyMyHeart.setImageResource(R.drawable.icon_favorite_24px)
+                        // 상태 태그 업데이트
+                        imageViewStudyMyHeart.tag = R.drawable.icon_favorite_24px
+
+                        // 틴트 제거 (원래 아이콘 색상으로 복원)
+                        imageViewStudyMyHeart.clearColorFilter()
+                    }
+                }
+                with(imageViewStudyMyHeart){
+                    setOnClickListener {
+                        toggleLikeButton()
+                    }
                 }
             }
         }

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/vm/StudyViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/vm/StudyViewModel.kt
@@ -1,7 +1,10 @@
 package kr.co.lion.modigm.ui.study.vm
 
 import androidx.lifecycle.ViewModel
+import kr.co.lion.modigm.repository.StudyRepository
 
 class StudyViewModel : ViewModel() {
+
+    private val studyRepository = StudyRepository()
 
 }

--- a/app/src/main/java/kr/co/lion/modigm/util/FragmentName.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/FragmentName.kt
@@ -1,7 +1,5 @@
 package kr.co.lion.modigm.util
 
-import kr.co.lion.modigm.ui.like.LikeFragment
-
 // MainActivity에서 보여줄 프레그먼트들의 이름
 enum class FragmentName (var str: String){
 
@@ -35,6 +33,7 @@ enum class FragmentName (var str: String){
     // 스터디
     STUDY("StudyFragment"),
     FILTER_SORT("FilterSortFragment"),
+    BOTTOM_NAVI("BottomNaviFragment"),
 
     // 글 작성
     WRITE("WriteFragment"),

--- a/app/src/main/res/layout/fragment_bottom_navi.xml
+++ b/app/src/main/res/layout/fragment_bottom_navi.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/bottomNaviContainerFull"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:transitionGroup="true"
+    tools:context=".ui.study.BottomNaviFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+
+        <FrameLayout
+            android:id="@+id/bottomNaviContainer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="9"
+            android:background="@color/white">
+
+        </FrameLayout>
+
+        <com.google.android.material.divider.MaterialDivider
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            app:dividerColor="@color/dividerView" />
+
+        <com.google.android.material.bottomnavigation.BottomNavigationView
+            android:id="@+id/bottomNavigationView"
+            android:layout_width="match_parent"
+            android:layout_height="80dp"
+            android:layout_weight="1"
+            android:background="@color/white"
+            android:paddingVertical="2dp"
+            app:itemActiveIndicatorStyle="@null"
+            app:itemBackground="@android:color/transparent"
+            app:itemIconSize="24dp"
+            app:itemIconTint="@color/bottom_navigation_selector_color"
+            app:itemTextColor="@color/bottom_navigation_selector_color"
+            app:labelVisibilityMode="labeled"
+            app:menu="@menu/menu_study_bottom_navi" />
+    </LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_filter_sort.xml
+++ b/app/src/main/res/layout/fragment_filter_sort.xml
@@ -5,7 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context=".ui.study.FilterSortFragment" >
+    tools:context=".ui.study.FilterSortFragment"
+    android:transitionGroup="true">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbarFilter"

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.login.LoginFragment">
+    tools:context=".ui.login.LoginFragment"
+    android:transitionGroup="true">
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/imageViewLoginBackground"

--- a/app/src/main/res/layout/fragment_study.xml
+++ b/app/src/main/res/layout/fragment_study.xml
@@ -1,38 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/fragmentContainerStudyFull"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context=".ui.study.StudyFragment">
+    tools:context=".ui.study.StudyFragment"
+    android:transitionGroup="true">
 
-    <LinearLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="match_parent">
 
-        <LinearLayout
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appBarLayout"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:orientation="vertical">
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/white">
 
-            <com.google.android.material.appbar.AppBarLayout
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbarStudy"
+                style="@style/CustomToolbar"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:backgroundTint="@color/white">
-
-                <com.google.android.material.appbar.MaterialToolbar
-                    android:id="@+id/toolbarStudy"
-                    style="@style/CustomToolbar"
-                    android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize"
-                    app:navigationIcon="@drawable/logo_toolbar_modigm"
-                    app:title="모우다임"
-                    app:titleCentered="true"
-                    app:titleTextAppearance="@style/toolbarText" />
-            </com.google.android.material.appbar.AppBarLayout>
+                android:layout_height="?attr/actionBarSize"
+                app:layout_scrollFlags="scroll|enterAlways"
+                app:navigationIcon="@drawable/logo_toolbar_modigm"
+                app:title="모우다임"
+                app:titleCentered="true"
+                app:titleTextAppearance="@style/toolbarText" />
 
             <com.google.android.material.tabs.TabLayout
                 android:id="@+id/tabLayoutStudy"
@@ -40,6 +36,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:backgroundTint="@color/white"
+                app:layout_collapseMode="pin"
                 app:tabIndicatorColor="@color/pointColor"
                 app:tabIndicatorHeight="2dp"
                 app:tabSelectedTextColor="@color/pointColor"
@@ -58,42 +55,27 @@
 
             </com.google.android.material.tabs.TabLayout>
 
-            <FrameLayout
-                android:id="@+id/fragmentContainerStudy"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
+        </com.google.android.material.appbar.AppBarLayout>
 
-            </FrameLayout>
-        </LinearLayout>
-
-
-
-        <com.google.android.material.bottomnavigation.BottomNavigationView
-            android:id="@+id/bottomNavigationView"
+        <FrameLayout
+            android:id="@+id/fragmentContainerStudy"
             android:layout_width="match_parent"
-            android:layout_height="80dp"
-            android:background="@color/white"
-            android:paddingVertical="5dp"
-            app:itemActiveIndicatorStyle="@null"
-            app:itemBackground="@android:color/transparent"
-            app:itemIconSize="24dp"
-            app:itemIconTint="@color/black"
-            app:itemTextColor="@color/black"
-            app:labelVisibilityMode="labeled"
-            app:menu="@menu/menu_study_bottom_navi" />
-    </LinearLayout>
-
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/fabStudyWrite"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/icon_edit_24px"
-        app:fabSize="normal"
-        android:layout_gravity="end|bottom"
-        android:layout_marginEnd="20dp"
-        android:layout_marginBottom="100dp"
-        android:backgroundTint="@color/pointColor"
-        app:tint="@color/white"/>
+            android:layout_height="match_parent"
+            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
+        </FrameLayout>
 
 
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fabStudyWrite"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|bottom"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="20dp"
+            android:backgroundTint="@color/pointColor"
+            android:src="@drawable/icon_edit_24px"
+            app:fabSize="normal"
+            app:tint="@color/white"
+            />
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_study_all.xml
+++ b/app/src/main/res/layout/fragment_study_all.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:transitionGroup="true">
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_study_my.xml
+++ b/app/src/main/res/layout/fragment_study_my.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:transitionGroup="true">
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
## #️⃣연관된 이슈

> #81 

## 📝작업 내용

> 스터디 목록관련 화면전환, 리사이클러뷰 데이터 연동 준비, 바텀내비게이션 구현 등 작업했습니다!

### 스크린샷 (선택)

|전체 스터디|내 스터디|
|:---:|:---:|
|<img width="305" alt="image" src="https://github.com/APP-Android2/FinalProject-modigm/assets/79239041/8925a3ae-3324-479b-af6b-ae140f362c49">|<img width="305" alt="image" src="https://github.com/APP-Android2/FinalProject-modigm/assets/79239041/c6ba92b7-9403-4049-ad2a-c7a7bb6edc44">|

|스크롤 할 경우|
|:---:|
|<img width="304" alt="image" src="https://github.com/APP-Android2/FinalProject-modigm/assets/79239041/9c9dd0e5-1db1-4a77-a310-8c488305f50c">|

## 💬리뷰 요구사항(선택)

현재 데이터 연결이 안되어 있어서 목록은 나타나지 않네요!
데이터베이스 연동은 상황상 내일로 미뤘고(오히려 좋아) 미뤄뒀던 필터 화면과 로그인 API를 먼저 해봐야겠습니다. 
편하게 지적해주세요!