### PR TITLE
[#85] feature - 채팅 읽음안읽음 메시지 관련 데이터 처리

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,13 +1,13 @@
 {
   "project_info": {
-    "project_number": "345647357022",
-    "project_id": "modigm-202ab",
-    "storage_bucket": "modigm-202ab.appspot.com"
+    "project_number": "411401156247",
+    "project_id": "modigm-4afde",
+    "storage_bucket": "modigm-4afde.appspot.com"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:345647357022:android:dc64a4c2f73ba4b2ffa8cf",
+        "mobilesdk_app_id": "1:411401156247:android:265756a66b4d5d59995bd2",
         "android_client_info": {
           "package_name": "kr.co.lion.modigm"
         }
@@ -15,7 +15,7 @@
       "oauth_client": [],
       "api_key": [
         {
-          "current_key": "AIzaSyDubDRLbCStzjCuZ2VhTAqXGvjk_b9DE0A"
+          "current_key": "AIzaSyCchS6Upzia9Fx-5O53diFKzloz35aeO58"
         }
       ],
       "services": {

--- a/app/src/main/java/kr/co/lion/modigm/model/ChatMessagesData.kt
+++ b/app/src/main/java/kr/co/lion/modigm/model/ChatMessagesData.kt
@@ -7,7 +7,6 @@ data class ChatMessagesData(
     val chatMessage: String, // 채팅 메세지 내용
     val chatFullTime : Long, // 메시지 고유 Index
     val chatTime: String, // 채팅 전송한 시간
-    var read: Boolean = false // 읽음/안 읽음 상태를 나타내는 플래그
 ) {
     constructor(): this(0,"", "", "",0L, "")
 }

--- a/app/src/main/java/kr/co/lion/modigm/model/ChatRoomData.kt
+++ b/app/src/main/java/kr/co/lion/modigm/model/ChatRoomData.kt
@@ -10,7 +10,6 @@ data class ChatRoomData(
     val lastChatMessage: String = "",
     val lastChatFullTime: Long = 0,
     val lastChatTime: String = "",
-    val chatMemberState: MutableMap<String, Boolean> = mutableMapOf(), // 현재 채팅방 참여 상태
     val unreadMessageCount: MutableMap<String, Int> = mutableMapOf() // 사용자별 안 읽은 메시지 개수를 추적하는 필드
 ) {
     constructor(): this(

--- a/app/src/main/java/kr/co/lion/modigm/model/ChatRoomData.kt
+++ b/app/src/main/java/kr/co/lion/modigm/model/ChatRoomData.kt
@@ -10,7 +10,7 @@ data class ChatRoomData(
     val lastChatMessage: String = "",
     val lastChatFullTime: Long = 0,
     val lastChatTime: String = "",
-    val lastReadTimestamp: MutableMap<String, Long> = mutableMapOf(), // 각 참여자의 마지막으로 읽은 메시지의 타임스탬프
+    val chatMemberState: MutableMap<String, Boolean> = mutableMapOf(), // 현재 채팅방 참여 상태
     val unreadMessageCount: MutableMap<String, Int> = mutableMapOf() // 사용자별 안 읽은 메시지 개수를 추적하는 필드
 ) {
     constructor(): this(

--- a/app/src/main/java/kr/co/lion/modigm/model/ChatRoomData.kt
+++ b/app/src/main/java/kr/co/lion/modigm/model/ChatRoomData.kt
@@ -10,8 +10,11 @@ data class ChatRoomData(
     val lastChatMessage: String = "",
     val lastChatFullTime: Long = 0,
     val lastChatTime: String = "",
-    val lastReadTimestamp: Map<String, Long> = mutableMapOf("1" to 0L), // 각 참여자의 마지막으로 읽은 메시지의 타임스탬프
-    var unreadMessageCount: Int = 0 // 안 읽은 메시지 개수를 추적하는 필드
+    val lastReadTimestamp: MutableMap<String, Long> = mutableMapOf(), // 각 참여자의 마지막으로 읽은 메시지의 타임스탬프
+    val unreadMessageCount: MutableMap<String, Int> = mutableMapOf() // 사용자별 안 읽은 메시지 개수를 추적하는 필드
 ) {
-    constructor(): this(0,"", "", listOf(), 2, false, "", 0, "", mutableMapOf("1" to 0L), 0)
+    constructor(): this(
+        0,"", "", listOf(), 2, false,
+        "", 0, "",
+    )
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatFragment.kt
@@ -55,13 +55,6 @@ class ChatFragment : Fragment() {
         viewPagerActiviation()
     }
 
-    override fun onResume() {
-        super.onResume()
-        Log.d("test1234", "ChatFragment - onResume")
-        // 채팅 방 데이터 갱신 (임시)
-        // viewPagerActiviation()
-    }
-
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.menu_chat_toolbar, menu)
@@ -156,6 +149,7 @@ class ChatFragment : Fragment() {
 
             // 채팅 방 생성
             ChatRoomDao.insertChatRoomData(chatRoomData)
+            Log.d("test1234", "${chatTitle} 채팅방 생성 완료")
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatGroupFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatGroupFragment.kt
@@ -34,14 +34,19 @@ class ChatGroupFragment : Fragment() {
         fragmentChatGroupBinding = FragmentChatGroupBinding.inflate(layoutInflater)
         mainActivity = activity as MainActivity
 
+        return fragmentChatGroupBinding.root
+    }
+
+    // 뷰가 생성된 직후 호출
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
         // RecyclerView 초기화
         setupRecyclerView()
 
         // 내가 속한 그룹 채팅 방(RecyclerView)
         gettingGroupChatRoomData()
         updateChatRoomData()
-
-        return fragmentChatGroupBinding.root
     }
 
     // RecyclerView 초기화

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatGroupFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatGroupFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -33,25 +34,14 @@ class ChatGroupFragment : Fragment() {
         fragmentChatGroupBinding = FragmentChatGroupBinding.inflate(layoutInflater)
         mainActivity = activity as MainActivity
 
-        val chatViewModel = ViewModelProvider(requireActivity()).get(ChatViewModel::class.java)
-        chatViewModel.updateChatRoomData.observe(viewLifecycleOwner) {
-            gettingGroupChatRoomData()
-        }
-
-        // Recycler 뷰
+        // RecyclerView 초기화
         setupRecyclerView()
 
         // 내가 속한 그룹 채팅 방(RecyclerView)
         gettingGroupChatRoomData()
+        updateChatRoomData()
 
         return fragmentChatGroupBinding.root
-    }
-
-    override fun onResume() {
-        super.onResume()
-        // 프래그먼트가 다시 활성화될 때 데이터 갱신
-        Log.d("test1234", "ChatGroupFragment - onResume")
-        // gettingGroupChatRoomData()
     }
 
     // RecyclerView 초기화
@@ -60,9 +50,16 @@ class ChatGroupFragment : Fragment() {
         fragmentChatGroupBinding.recyclerViewChatGroup.apply {
             layoutManager = LinearLayoutManager(requireContext())
             adapter = ChatRoomAdapter(chatRoomDataList, { roomItem ->
-                // 대화방 선택 시 동작
                 Log.d("test1234", "${roomItem.chatIdx}번 ${roomItem.chatTitle}에 입장")
             }, mainActivity, loginUserId)
+        }
+    }
+
+    // 채팅방 변경시 업데이트
+    private fun updateChatRoomData(){
+        val chatViewModel = ViewModelProvider(requireActivity()).get(ChatViewModel::class.java)
+        chatViewModel.updateChatRoomData.observe(viewLifecycleOwner) {
+            gettingGroupChatRoomData()
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatGroupFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatGroupFragment.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.firebase.firestore.ListenerRegistration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -16,6 +17,7 @@ import kr.co.lion.modigm.databinding.FragmentChatGroupBinding
 import kr.co.lion.modigm.model.ChatRoomData
 import kr.co.lion.modigm.ui.MainActivity
 import kr.co.lion.modigm.ui.chat.adapter.ChatRoomAdapter
+import kr.co.lion.modigm.ui.chat.adapter.MessageAdapter
 import kr.co.lion.modigm.ui.chat.dao.ChatRoomDao
 import kr.co.lion.modigm.ui.chat.vm.ChatViewModel
 
@@ -23,6 +25,7 @@ class ChatGroupFragment : Fragment() {
 
     lateinit var fragmentChatGroupBinding: FragmentChatGroupBinding
     lateinit var mainActivity: MainActivity
+    private lateinit var chatRoomAdapter: ChatRoomAdapter
 
     // 내가 속한 그룹 채팅 방들을 담고 있을 리스트
     var chatRoomDataList = mutableListOf<ChatRoomData>()
@@ -44,9 +47,23 @@ class ChatGroupFragment : Fragment() {
         // RecyclerView 초기화
         setupRecyclerView()
 
-        // 내가 속한 그룹 채팅 방(RecyclerView)
-        gettingGroupChatRoomData()
-        updateChatRoomData()
+        // 실시간 채팅 방 데이터 업데이트
+        getAndUpdateLiveChatRooms()
+    }
+
+    // 실시간 채팅 방 데이터 업데이트
+    private fun getAndUpdateLiveChatRooms(){
+        // 내가 속한 그룹 채팅 방(RecyclerView)를 실시간으로 업데이트
+        ChatRoomDao.updateChatRoomsListener(loginUserId, groupChat = true) { updatedChatRooms ->
+            chatRoomDataList.clear()
+            chatRoomDataList.addAll(updatedChatRooms)
+
+            // RecyclerView 갱신
+            activity?.runOnUiThread {
+                fragmentChatGroupBinding.recyclerViewChatGroup.adapter?.notifyDataSetChanged()
+            }
+            Log.d("test1234", "실시간 업데이트 실행 - Group")
+        }
     }
 
     // RecyclerView 초기화
@@ -54,34 +71,10 @@ class ChatGroupFragment : Fragment() {
         // 대화방 목록 RecyclerView 설정
         fragmentChatGroupBinding.recyclerViewChatGroup.apply {
             layoutManager = LinearLayoutManager(requireContext())
-            adapter = ChatRoomAdapter(chatRoomDataList, { roomItem ->
+            chatRoomAdapter = ChatRoomAdapter(chatRoomDataList, { roomItem ->
                 Log.d("test1234", "${roomItem.chatIdx}번 ${roomItem.chatTitle}에 입장")
             }, mainActivity, loginUserId)
-        }
-    }
-
-    // 채팅방 변경시 업데이트
-    private fun updateChatRoomData(){
-        val chatViewModel = ViewModelProvider(requireActivity()).get(ChatViewModel::class.java)
-        chatViewModel.updateChatRoomData.observe(viewLifecycleOwner) {
-            gettingGroupChatRoomData()
-        }
-    }
-
-    // 내가 속한 모든 그룹 채팅 방을 가져와 화면의 RecyclerView를 갱신한다.
-    fun gettingGroupChatRoomData() {
-        CoroutineScope(Dispatchers.Main).launch {
-            // 대화방 목록 데이터 가져오기
-            val newChatRoomDataList = ChatRoomDao.getGroupChatRooms("currentUser")
-
-            // 새로운 목록으로 업데이트
-            chatRoomDataList.clear()
-            chatRoomDataList.addAll(newChatRoomDataList)
-
-            // RecyclerView 갱신
-            activity?.runOnUiThread {
-                fragmentChatGroupBinding.recyclerViewChatGroup.adapter?.notifyDataSetChanged()
-            }
+            adapter = chatRoomAdapter
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatGroupFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatGroupFragment.kt
@@ -26,6 +26,8 @@ class ChatGroupFragment : Fragment() {
     // 내가 속한 그룹 채팅 방들을 담고 있을 리스트
     var chatRoomDataList = mutableListOf<ChatRoomData>()
 
+    private val loginUserId = "currentUser" // 현재 사용자의 ID를 설정 (DB 연동 후 교체)
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 
         fragmentChatGroupBinding = FragmentChatGroupBinding.inflate(layoutInflater)
@@ -60,7 +62,7 @@ class ChatGroupFragment : Fragment() {
             adapter = ChatRoomAdapter(chatRoomDataList, { roomItem ->
                 // 대화방 선택 시 동작
                 Log.d("test1234", "${roomItem.chatIdx}번 ${roomItem.chatTitle}에 입장")
-            }, mainActivity)
+            }, mainActivity, loginUserId)
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatOnetoOneFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatOnetoOneFragment.kt
@@ -37,18 +37,22 @@ class ChatOnetoOneFragment : Fragment() {
             gettingOneToOneChatRoomData()
         }
 
-        gettingOneToOneChatRoomData()
-
         // RecyclerView 초기화
         setupRecyclerView()
+
+        // 내가 속한 그룹 채팅 방(RecyclerView)
+        gettingOneToOneChatRoomData()
+        updateChatRoomData()
 
         return fragmentChatOnetoOneBinding.root
     }
 
-    override fun onResume() {
-        super.onResume()
-        // 프래그먼트가 다시 활성화될 때 데이터 갱신
-        gettingOneToOneChatRoomData()
+    // 채팅방 변경시 업데이트
+    private fun updateChatRoomData(){
+        val chatViewModel = ViewModelProvider(requireActivity()).get(ChatViewModel::class.java)
+        chatViewModel.updateChatRoomData.observe(viewLifecycleOwner) {
+            gettingOneToOneChatRoomData()
+        }
     }
 
     // RecyclerView 초기화

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatOnetoOneFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatOnetoOneFragment.kt
@@ -26,6 +26,8 @@ class ChatOnetoOneFragment : Fragment() {
     // 내가 속한 1:1 채팅 방들을 담고 있을 리스트
     var chatRoomDataList = mutableListOf<ChatRoomData>()
 
+    private val loginUserId = "currentUser" // 현재 사용자의 ID를 설정 (DB 연동 후 교체)
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         fragmentChatOnetoOneBinding = FragmentChatOnetoOneBinding.inflate(layoutInflater)
         mainActivity = activity as MainActivity
@@ -58,7 +60,7 @@ class ChatOnetoOneFragment : Fragment() {
             adapter = ChatRoomAdapter(chatRoomDataList, { roomItem ->
                 // 대화방 선택 시 동작
                 Log.d("test1234", "Selected Room: ${roomItem.chatTitle}")
-            }, mainActivity)
+            }, mainActivity, loginUserId)
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatOnetoOneFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatOnetoOneFragment.kt
@@ -32,10 +32,12 @@ class ChatOnetoOneFragment : Fragment() {
         fragmentChatOnetoOneBinding = FragmentChatOnetoOneBinding.inflate(layoutInflater)
         mainActivity = activity as MainActivity
 
-        val chatViewModel = ViewModelProvider(requireActivity()).get(ChatViewModel::class.java)
-        chatViewModel.updateChatRoomData.observe(viewLifecycleOwner) {
-            gettingOneToOneChatRoomData()
-        }
+        return fragmentChatOnetoOneBinding.root
+    }
+
+    // 뷰가 생성된 직후 호출
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
         // RecyclerView 초기화
         setupRecyclerView()
@@ -43,16 +45,6 @@ class ChatOnetoOneFragment : Fragment() {
         // 내가 속한 그룹 채팅 방(RecyclerView)
         gettingOneToOneChatRoomData()
         updateChatRoomData()
-
-        return fragmentChatOnetoOneBinding.root
-    }
-
-    // 채팅방 변경시 업데이트
-    private fun updateChatRoomData(){
-        val chatViewModel = ViewModelProvider(requireActivity()).get(ChatViewModel::class.java)
-        chatViewModel.updateChatRoomData.observe(viewLifecycleOwner) {
-            gettingOneToOneChatRoomData()
-        }
     }
 
     // RecyclerView 초기화
@@ -65,6 +57,14 @@ class ChatOnetoOneFragment : Fragment() {
                 // 대화방 선택 시 동작
                 Log.d("test1234", "Selected Room: ${roomItem.chatTitle}")
             }, mainActivity, loginUserId)
+        }
+    }
+
+    // 채팅방 변경시 업데이트
+    private fun updateChatRoomData(){
+        val chatViewModel = ViewModelProvider(requireActivity()).get(ChatViewModel::class.java)
+        chatViewModel.updateChatRoomData.observe(viewLifecycleOwner) {
+            gettingOneToOneChatRoomData()
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatOnetoOneFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatOnetoOneFragment.kt
@@ -42,9 +42,23 @@ class ChatOnetoOneFragment : Fragment() {
         // RecyclerView 초기화
         setupRecyclerView()
 
-        // 내가 속한 그룹 채팅 방(RecyclerView)
-        gettingOneToOneChatRoomData()
-        updateChatRoomData()
+        // 실시간 채팅 방 데이터 업데이트
+        getAndUpdateLiveChatRooms()
+    }
+
+    // 실시간 채팅 방 데이터 업데이트
+    private fun getAndUpdateLiveChatRooms(){
+        // 내가 속한 그룹 채팅 방(RecyclerView)를 실시간으로 업데이트
+        ChatRoomDao.updateChatRoomsListener(loginUserId, groupChat = false) { updatedChatRooms ->
+            chatRoomDataList.clear()
+            chatRoomDataList.addAll(updatedChatRooms)
+
+            // RecyclerView 갱신
+            activity?.runOnUiThread {
+                fragmentChatOnetoOneBinding.recyclerViewChatOnetoOne.adapter?.notifyDataSetChanged()
+            }
+            Log.d("test1234", "실시간 업데이트 실행 - 1:1")
+        }
     }
 
     // RecyclerView 초기화
@@ -57,31 +71,6 @@ class ChatOnetoOneFragment : Fragment() {
                 // 대화방 선택 시 동작
                 Log.d("test1234", "Selected Room: ${roomItem.chatTitle}")
             }, mainActivity, loginUserId)
-        }
-    }
-
-    // 채팅방 변경시 업데이트
-    private fun updateChatRoomData(){
-        val chatViewModel = ViewModelProvider(requireActivity()).get(ChatViewModel::class.java)
-        chatViewModel.updateChatRoomData.observe(viewLifecycleOwner) {
-            gettingOneToOneChatRoomData()
-        }
-    }
-
-    // 내가 속한 모든 그룹 채팅 방을 가져와 화면의 RecyclerView를 갱신한다.
-    fun gettingOneToOneChatRoomData() {
-        CoroutineScope(Dispatchers.Main).launch {
-            // 대화방 목록 데이터 가져오기
-            val newChatRoomDataList = ChatRoomDao.getOneToOneChatRooms("currentUser")
-
-            // 새로운 목록으로 업데이트
-            chatRoomDataList.clear()
-            chatRoomDataList.addAll(newChatRoomDataList)
-
-            // UI 스레드에서 RecyclerView를 갱신
-            activity?.runOnUiThread {
-                fragmentChatOnetoOneBinding.recyclerViewChatOnetoOne.adapter?.notifyDataSetChanged()
-            }
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatRoomFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatRoomFragment.kt
@@ -40,10 +40,12 @@ class ChatRoomFragment : Fragment() {
     lateinit var mainActivity: MainActivity
     private lateinit var messageAdapter: MessageAdapter
 
+    private lateinit var chatRoomDao: ChatRoomDao
+
     // 보낼 메세지를 담고 있을 리스트
     private val messages = mutableListOf<ChatMessagesData>()
-    private val loginUserId = "currentUser" // 현재 사용자의 ID를 설정하세요
-    private val loginUserName = "김원빈" // 현재 사용자의 Name을 설정하세요
+    private val loginUserId = "currentUser" // 현재 사용자의 ID를 설정 (DB 연동 후 교체)
+    private val loginUserName = "김원빈" // 현재 사용자의 Name을 설정 (DB 연동 후 교체)
 
     private lateinit var chatViewModel: ChatViewModel
 
@@ -68,6 +70,13 @@ class ChatRoomFragment : Fragment() {
             isGroupChat = it.getBoolean("groupChat")
         }
 
+        // 채팅방에 입장할 때 실시간 업데이트 설정
+        // chatRoomDao = ChatRoomDao()
+        // chatRoomDao.enterChatRoom(chatIdx, loginUserId)
+
+        // 메시지 읽음 처리
+        readMessage()
+
         // 채팅 방 - (툴바) 세팅
         settingToolbar()
 
@@ -85,8 +94,9 @@ class ChatRoomFragment : Fragment() {
 
     override fun onDestroy() {
         super.onDestroy()
-        Log.d("test1234", "ChatRoomFragment - onDestroy")
+        Log.d("test1234", "ChatRoomFragment - onDestroy !!")
         chatViewModel.triggerChatRoomDataUpdate()
+        // chatRoomDao.leaveChatRoom()
     }
 
     // 툴바 세팅
@@ -191,6 +201,8 @@ class ChatRoomFragment : Fragment() {
 
                     // 전송 후 키보드 숨기기
                     activity?.hideSoftInput()
+
+                    ChatRoomDao.increaseUnreadMessageCount(chatIdx, chatSenderId)
                 }
             }
         }
@@ -269,6 +281,13 @@ class ChatRoomFragment : Fragment() {
     fun outChatRoom() {
         CoroutineScope(Dispatchers.Main).launch {
             ChatRoomDao.removeUserFromChatMemberList(chatIdx, loginUserId)
+        }
+    }
+
+    // 메세지 읽음 처리
+    fun readMessage() {
+        CoroutineScope(Dispatchers.Main).launch {
+            ChatRoomDao.chatRoomMessageAsRead(chatIdx, loginUserId)
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatRoomFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/ChatRoomFragment.kt
@@ -20,6 +20,7 @@ import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentChatRoomBinding
 import kr.co.lion.modigm.model.ChatMessagesData
 import kr.co.lion.modigm.ui.MainActivity
+import kr.co.lion.modigm.ui.chat.adapter.ChatRoomAdapter
 import kr.co.lion.modigm.ui.chat.adapter.MessageAdapter
 import kr.co.lion.modigm.ui.chat.dao.ChatMessagesDao
 import kr.co.lion.modigm.ui.chat.dao.ChatRoomDao
@@ -75,7 +76,7 @@ class ChatRoomFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         // 입장시 -> 메시지 읽음 처리
-        readMessage()
+        // readMessage()
 
         // 채팅 방 - (툴바) 세팅
         settingToolbar()
@@ -90,10 +91,12 @@ class ChatRoomFragment : Fragment() {
         getAndUpdateMessages()
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        Log.d("test1234", "ChatRoomFragment - onDestroy 실행")
-        chatViewModel.triggerChatRoomDataUpdate()
+
+    // Pause 상태 - 채팅방 나갈때도 포함되며 Destory에 안쓴 이유는 (onDestory 보다 먼저 실행되서...) 어차피 readMessage 처리 해야해서
+    override fun onPause() {
+        super.onPause()
+        Log.d("test1234", "ChatRoomFragment - onPause 실행")
+        readMessage()
     }
 
     // 툴바 세팅

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/adapter/ChatRoomAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/adapter/ChatRoomAdapter.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
@@ -18,7 +19,8 @@ import kr.co.lion.modigm.util.FragmentName
 class ChatRoomAdapter(
     private val roomList: List<ChatRoomData>,
     private val onItemClick: (ChatRoomData) -> Unit,
-    private val mainActivity: MainActivity
+    private val mainActivity: MainActivity,
+    private val loginUserId: String // 현재 사용자의 ID를 추가
 ) : RecyclerView.Adapter<ChatRoomAdapter.ChatRoomViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChatRoomViewHolder {
@@ -39,6 +41,7 @@ class ChatRoomAdapter(
         private val roomLastTextView: TextView = itemView.findViewById(R.id.textViewRowChatroomFiledLastMessage)
         private val roomTimeTextView: TextView = itemView.findViewById(R.id.textViewRowChatroomFiledTime)
         private val roomImageImageView: ImageView = itemView.findViewById(R.id.imageViewRowChatroomFiledImage)
+        private val roomMessageCountButton: Button = itemView.findViewById(R.id.buttonRowChatroomFiledMessageCount)
 
         init {
             itemView.setOnClickListener {
@@ -89,6 +92,15 @@ class ChatRoomAdapter(
                 roomLastTextView.text = room.lastChatMessage
                 // 마지막 채팅 시간
                 roomTimeTextView.text = room.lastChatTime
+            }
+
+            // 안 읽은 메시지 수 설정
+            val unreadCount = room.unreadMessageCount[loginUserId] ?: 0
+            if (unreadCount > 0) {
+                roomMessageCountButton.visibility = View.VISIBLE
+                roomMessageCountButton.text = unreadCount.toString()
+            } else {
+                roomMessageCountButton.visibility = View.GONE
             }
         }
     }

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/adapter/ChatRoomAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/adapter/ChatRoomAdapter.kt
@@ -12,12 +12,13 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.modigm.R
+import kr.co.lion.modigm.model.ChatMessagesData
 import kr.co.lion.modigm.model.ChatRoomData
 import kr.co.lion.modigm.ui.MainActivity
 import kr.co.lion.modigm.util.FragmentName
 
 class ChatRoomAdapter(
-    private val roomList: List<ChatRoomData>,
+    private val roomList: MutableList<ChatRoomData>,
     private val onItemClick: (ChatRoomData) -> Unit,
     private val mainActivity: MainActivity,
     private val loginUserId: String // 현재 사용자의 ID를 추가

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/adapter/MessageAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/adapter/MessageAdapter.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.modigm.ui.chat.adapter
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -53,6 +54,7 @@ class MessageAdapter(
     fun updateMessages(updatedMessages: List<ChatMessagesData>) {
         messages.clear()
         messages.addAll(updatedMessages)
+        Log.d("test1234", "messages: ${messages}")
         notifyDataSetChanged()
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/adapter/MessageAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/adapter/MessageAdapter.kt
@@ -1,6 +1,5 @@
 package kr.co.lion.modigm.ui.chat.adapter
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -54,7 +53,6 @@ class MessageAdapter(
     fun updateMessages(updatedMessages: List<ChatMessagesData>) {
         messages.clear()
         messages.addAll(updatedMessages)
-        Log.d("test1234", "messages: ${messages}")
         notifyDataSetChanged()
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/dao/ChatRoomDao.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/dao/ChatRoomDao.kt
@@ -1,9 +1,6 @@
 package kr.co.lion.modigm.ui.chat.dao
 
-import android.util.Log
 import com.google.firebase.Firebase
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.ListenerRegistration
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.firestore
 import kotlinx.coroutines.CoroutineScope
@@ -16,14 +13,18 @@ class ChatRoomDao {
 
     companion object{
 
-        // 채팅 방 시퀀스 번호를 Get 후 Int 형으로 반환
+        // 공통으로 쓰이는 collectionReferenceSequence - Sequence 로 설정
+        val collectionReferenceSequence = Firebase.firestore.collection("Sequence")
+        // 공통으로 쓰이는 collectionReference - ChatRoomData 로 설정
+        val collectionReference = Firebase.firestore.collection("ChatRoomData")
+
+        // 채팅 방 시퀀스 번호를 Get 후 반환함
         suspend fun getChatRoomSequence():Int{
 
             var chatRoomSequence = -1
 
             val coroutine1 = CoroutineScope(Dispatchers.IO).launch {
-                val collectionReference = Firebase.firestore.collection("Sequence")
-                val documentReference = collectionReference.document("ChatRoomSequence")
+                val documentReference = collectionReferenceSequence.document("ChatRoomSequence")
                 val documentSnapShot = documentReference.get().await()
                 chatRoomSequence = documentSnapShot.getLong("value")?.toInt()!!
             }
@@ -32,11 +33,10 @@ class ChatRoomDao {
             return chatRoomSequence
         }
 
-        // 채팅 방 시퀀스 값을 Update 한다.
+        // 채팅 방 시퀀스 값을 변경함 (Update)
         suspend fun updateChatRoomSequence(userSequence:Int){
             val coroutine1 = CoroutineScope(Dispatchers.IO).launch {
-                val collectionReference = Firebase.firestore.collection("Sequence")
-                val documentReference = collectionReference.document("ChatRoomSequence")
+                val documentReference = collectionReferenceSequence.document("ChatRoomSequence")
                 // 저장할 데이터를 담을 HashMap을 만들어준다.
                 val map = mutableMapOf<String, Long>()
                 map["value"] = userSequence.toLong()
@@ -46,22 +46,19 @@ class ChatRoomDao {
             coroutine1.join()
         }
 
-        // 채팅 방을 Create 한다.
+        // 채팅 방을 생성함 (Create)
         suspend fun insertChatRoomData(chatRoomData: ChatRoomData){
             val coroutine1 = CoroutineScope(Dispatchers.IO).launch {
-                val collectionReference = Firebase.firestore.collection("ChatRoomData")
                 collectionReference.add(chatRoomData)
             }
             coroutine1.join()
         }
 
-        // 단체 채팅방 데이터 가져오기
+        // 단체 채팅방 데이터 가져옴 (Read)
         suspend fun getGroupChatRooms(userId: String): MutableList<ChatRoomData> {
             var chatRooms = mutableListOf<ChatRoomData>()
 
             val coroutine1 = CoroutineScope(Dispatchers.IO).launch {
-                val collectionReference = Firebase.firestore.collection("ChatRoomData")
-
                 // 내 아이디의 chatIdx 와 groupChat이 true인 경우 필터링
                 // chatIdx는 UserData가 있다면 그 Data에서 아이디 별 소속해있는 채팅방 int형 list를 가져와야함.
                 val querySnapshot = collectionReference
@@ -83,13 +80,11 @@ class ChatRoomDao {
             return chatRooms
         }
 
-        // 1:1 채팅방 데이터 가져오기
+        // 1:1 채팅방 데이터 가져옴 (Read)
         suspend fun getOneToOneChatRooms(userId: String): MutableList<ChatRoomData> {
             var chatRooms = mutableListOf<ChatRoomData>()
 
             val coroutine1 = CoroutineScope(Dispatchers.IO).launch {
-                val collectionReference = Firebase.firestore.collection("ChatRoomData")
-
                 // 내 아이디의 chatIdx 와 groupChat이 true인 경우 필터링
                 // chatIdx는 UserData가 있다면 그 Data에서 아이디 별 소속해있는 채팅방 int형 list를 가져와야함.
                 val querySnapshot = collectionReference
@@ -111,13 +106,11 @@ class ChatRoomDao {
             return chatRooms
         }
 
-        // 해당 채팅방 마지막 메세지, 마지막 메세지 시간 저장
+        // 해당 채팅방 데이터 [마지막 메세지, 마지막 메세지 시간] 변경함 (Update)
         suspend fun updateChatRoomLastMessageAndTime(chatIdx: Int, chatMessage: String, chatFullTime: Long, chatTime: String): MutableList<ChatRoomData> {
             var chatRooms = mutableListOf<ChatRoomData>()
 
             val coroutine1 = CoroutineScope(Dispatchers.IO).launch {
-                val collectionReference = Firebase.firestore.collection("ChatRoomData")
-
                 // 내 아이디의 chatIdx 와 groupChat이 true인 경우 필터링
                 // chatIdx는 UserData가 있다면 그 Data에서 아이디 별 소속해있는 채팅방 int형 list를 가져와야함.
                 val querySnapshot = collectionReference
@@ -141,11 +134,9 @@ class ChatRoomDao {
             return chatRooms
         }
 
-        // chatMemberList 배열에서 내 ID를 제거
+        // 채팅방 나가기 / chatMemberList 배열에서 내 ID를 제거 (Update)
         suspend fun removeUserFromChatMemberList(chatIdx: Int, userId: String) {
             val coroutine1 = CoroutineScope(Dispatchers.IO).launch {
-                val collectionReference = Firebase.firestore.collection("ChatRoomData")
-
                 val querySnapshot = collectionReference
                     .whereEqualTo("chatIdx", chatIdx)
                     .get()
@@ -161,11 +152,10 @@ class ChatRoomDao {
             coroutine1.join()
         }
 
-        // 사용자가 메세지 읽음 처리
+        // 로그인 한 사용자 해당 채팅 방 메세지 읽음 처리 (Update)
         suspend fun chatRoomMessageAsRead(chatIdx: Int, loginUserId: String) {
             val coroutine1 = CoroutineScope(Dispatchers.IO).launch {
-                val chatRoomRef = Firebase.firestore.collection("ChatRoomData")
-                    .whereEqualTo("chatIdx", chatIdx)
+                val chatRoomRef = collectionReference.whereEqualTo("chatIdx", chatIdx)
                 val querySnapshot = chatRoomRef.get().await()
                 querySnapshot.forEach { document ->
                     val chatRoom = document.toObject(ChatRoomData::class.java)
@@ -178,16 +168,14 @@ class ChatRoomDao {
             coroutine1.join()
         }
 
-        // 새로운 메시지 도착 시 안 읽은 메시지 개수 증가
+        // 메세지 전송시 해당 채팅 방 사용자에 안읽은 메세지 카운트 증가 
         suspend fun increaseUnreadMessageCount(chatIdx: Int, senderId: String) {
             val coroutine1 = CoroutineScope(Dispatchers.IO).launch {
-                val chatRoomRef = Firebase.firestore.collection("ChatRoomData")
-                    .whereEqualTo("chatIdx", chatIdx)
+                val chatRoomRef = collectionReference.whereEqualTo("chatIdx", chatIdx)
                 val querySnapshot = chatRoomRef.get().await()
                 querySnapshot.forEach { document ->
                     val chatRoom = document.toObject(ChatRoomData::class.java)
                     chatRoom?.let {
-                        val now = System.currentTimeMillis()
                         for (participant in it.chatMemberList) {
                             // 현재 입장 여부 확인
 //                            if (participant != senderId && it.chatMemberState[participant] == false) {
@@ -207,7 +195,6 @@ class ChatRoomDao {
         // 멤버 입장 여부 업데이트
         suspend fun updateMemberState(chatIdx: Int, memberId: String, isPresent: Boolean) {
             val coroutine = CoroutineScope(Dispatchers.IO).launch {
-                val collectionReference = Firebase.firestore.collection("ChatRoomData")
                 val chatRoomRef = collectionReference.whereEqualTo("chatIdx", chatIdx)
                 val querySnapshot = chatRoomRef.get().await()
                 querySnapshot.forEach { document ->

--- a/app/src/main/java/kr/co/lion/modigm/ui/chat/vm/ChatViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/chat/vm/ChatViewModel.kt
@@ -6,12 +6,4 @@ import androidx.lifecycle.ViewModel
 
 class ChatViewModel : ViewModel() {
 
-    // ChatGroupFragment의 데이터 갱신을 감지하기 위한 LiveData
-    private val _updateChatRoomData = MutableLiveData<Unit>()
-    val updateChatRoomData: LiveData<Unit> = _updateChatRoomData
-
-    // ChatRoomFragment에서 호출하여 ChatGroupFragment의 데이터를 갱신
-    fun triggerChatRoomDataUpdate() {
-        _updateChatRoomData.value = Unit
-    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #85 

## 📝작업 내용

채팅 읽음/안읽음 메시지 관련 데이터 처리하여 채팅방 옆에 안읽은 개수가 바뀌도록 하였습니다

### 스크린샷 (선택)
![1번](https://github.com/APP-Android2/FinalProject-modigm/assets/103239379/bc579938-c697-46a0-9800-bb550ecd9985)
![2번](https://github.com/APP-Android2/FinalProject-modigm/assets/103239379/c0e913e1-4388-4632-95d7-253b96027851)

## 💬리뷰 요구사항(선택)

첫 번째 사진은 그냥 에뮬레이터 3개 띄워서 채팅 잘 되고있는 모습의 사진이며
두 번째 사진은 이번에 추가하게 된 읽지 않은 메시지의 개수를 띄워 줄 수 있는 사진입니다.
수정해야 할 부분이나 추가해야 할 부분이 있다면 말씀부탁드립니다.
없다면 5시 되기 전 쉬는시간에 머지 하겠습니다.