### PR TITLE
[Feature #104] 게시글 수정 화면 장소 선택 bottomsheet 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,4 +74,7 @@ dependencies {
 
     // 원형 이미지 라이브러리
     implementation("de.hdodenhof:circleimageview:3.1.0")
+
+    // 구글 장소 api
+    implementation("com.google.android.libraries.places:places:3.3.0")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
@@ -15,8 +17,22 @@ android {
         versionCode = 1
         versionName = "1.0"
 
+        // Kotlin DSL에서는 아래와 같이 API 키를 추가합니다.
+        val localProperties = Properties()
+        val localPropertiesFile = rootProject.file("local.properties")
+        if (localPropertiesFile.exists()) {
+            localProperties.load(localPropertiesFile.inputStream())
+        }
+        val placeApiKey = localProperties.getProperty("place_api_key") ?: ""
+
+        buildConfigField("String", "PLACE_API_KEY", "$placeApiKey")
+
+        // manifestPlaceholders 설정
+        manifestPlaceholders["PLACE_API_KEY"] = placeApiKey
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
+
 
     buildTypes {
         release {
@@ -38,6 +54,7 @@ android {
     buildFeatures {
         viewBinding = true
         dataBinding = true
+        buildConfig = true
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="AIzaSyA1g5zt54augc0j2X_ZIJg4ZwAdwPsgzfE"/>
+
     </application>
 
     <uses-permission android:name="android.permission.INTERNET" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyCvwwUD0SngnM5gAhvdStSatfMHf03WvsI"/>
+            android:value="${PLACE_API_KEY}"/>
 
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyA1g5zt54augc0j2X_ZIJg4ZwAdwPsgzfE"/>
+            android:value="AIzaSyCvwwUD0SngnM5gAhvdStSatfMHf03WvsI"/>
 
     </application>
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailEditFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailEditFragment.kt
@@ -213,6 +213,12 @@ class DetailEditFragment : Fragment(), OnSkillSelectedListener {
             bottomSheet.show(childFragmentManager, bottomSheet.tag)
         }
 
+        // 프래그 먼트간 연결 설정
+        fragmentDetailEditBinding.textInputLayoutDetailEditPlace.editText?.setOnClickListener {
+            val bottomSheet = PlaceBottomSheetFragment()
+            bottomSheet.show(childFragmentManager,bottomSheet.tag)
+        }
+
     }
 
     fun setupButton() {

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailEditFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailEditFragment.kt
@@ -20,7 +20,7 @@ import kr.co.lion.modigm.ui.MainActivity
 import kr.co.lion.modigm.util.FragmentName
 
 
-class DetailEditFragment : Fragment(), OnSkillSelectedListener {
+class DetailEditFragment : Fragment(), OnSkillSelectedListener, OnPlaceSelectedListener {
 
     lateinit var fragmentDetailEditBinding: FragmentDetailEditBinding
 
@@ -47,6 +47,13 @@ class DetailEditFragment : Fragment(), OnSkillSelectedListener {
         setupChipGroups()
         preselectChips()
     }
+
+    // 인터페이스 구현
+    // bottomSheet에서 선택한 항목의 제목
+    override fun onPlaceSelected(placeName: String) {
+        fragmentDetailEditBinding.editTextDetailEditTitleLocation.setText(placeName)
+    }
+
     // 툴바 설정
     fun settingToolbar() {
         fragmentDetailEditBinding.apply {
@@ -215,7 +222,9 @@ class DetailEditFragment : Fragment(), OnSkillSelectedListener {
 
         // 프래그 먼트간 연결 설정
         fragmentDetailEditBinding.textInputLayoutDetailEditPlace.editText?.setOnClickListener {
-            val bottomSheet = PlaceBottomSheetFragment()
+            val bottomSheet = PlaceBottomSheetFragment().apply {
+                setOnPlaceSelectedListener(this@DetailEditFragment)
+            }
             bottomSheet.show(childFragmentManager,bottomSheet.tag)
         }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/OnPlaceSelectedListener.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/OnPlaceSelectedListener.kt
@@ -1,0 +1,6 @@
+package kr.co.lion.modigm.ui.detail
+
+// PlaceBottomSheet와 DetailEditFragment간의 통신을 위한 인터페이스 정의(주소 선택)
+interface OnPlaceSelectedListener {
+    fun onPlaceSelected(placeName: String)
+}

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/PlaceBottomSheetFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/PlaceBottomSheetFragment.kt
@@ -34,6 +34,8 @@ class PlaceBottomSheetFragment : BottomSheetDialogFragment() {
     private lateinit var binding: FragmentPlaceBottomSheetBinding
     private lateinit var placesClient: PlacesClient
 
+    private var placeSelectedListener: OnPlaceSelectedListener? = null
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -61,8 +63,14 @@ class PlaceBottomSheetFragment : BottomSheetDialogFragment() {
         }
     }
 
-    private fun setupSearchBar() {
+    // 선택된 주소 감지 이벤트 트리거
+    fun setOnPlaceSelectedListener(listener: OnPlaceSelectedListener) {
+        placeSelectedListener = listener
+    }
+
+    fun setupSearchBar() {
         val adapter = PlaceSearchResultsAdapter(mutableListOf()) { place ->
+            placeSelectedListener?.onPlaceSelected(place.name)
             dismiss()  // 바텀 시트 닫기
         }
         binding.recyclerViewSearchResults.adapter = adapter
@@ -95,13 +103,13 @@ class PlaceBottomSheetFragment : BottomSheetDialogFragment() {
         }
     }
 
-    private fun getScreenHeight(): Int {
+    fun getScreenHeight(): Int {
         val displayMetrics = DisplayMetrics()
         requireActivity().windowManager.defaultDisplay.getMetrics(displayMetrics)
         return displayMetrics.heightPixels
     }
 
-    private fun searchPlace(query: String, adapter: PlaceSearchResultsAdapter) {
+    fun searchPlace(query: String, adapter: PlaceSearchResultsAdapter) {
         val token = AutocompleteSessionToken.newInstance()
         val request = FindAutocompletePredictionsRequest.builder()
             .setSessionToken(token)

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/PlaceBottomSheetFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/PlaceBottomSheetFragment.kt
@@ -1,0 +1,136 @@
+package kr.co.lion.modigm.ui.detail
+
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.util.DisplayMetrics
+import android.util.Log
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import android.widget.FrameLayout
+import androidx.core.content.ContextCompat
+import com.google.android.libraries.places.api.Places
+import com.google.android.libraries.places.api.model.AutocompleteSessionToken
+import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
+import com.google.android.libraries.places.api.net.PlacesClient
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kr.co.lion.modigm.R
+import kr.co.lion.modigm.databinding.FragmentPlaceBottomSheetBinding
+import kr.co.lion.modigm.ui.detail.adapter.PlaceSearchResultsAdapter
+
+data class SimplePlace(
+    val id: String,
+    val name: String,
+    val address: String
+)
+
+class PlaceBottomSheetFragment : BottomSheetDialogFragment() {
+
+    private lateinit var binding: FragmentPlaceBottomSheetBinding
+    private lateinit var placesClient: PlacesClient
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentPlaceBottomSheetBinding.inflate(inflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        // bottomSheet 배경 설정
+        view.background =
+            ContextCompat.getDrawable(requireContext(), R.drawable.style_bottom_sheet_background)
+
+        if (!Places.isInitialized()) {
+            Places.initialize(requireContext(), "AIzaSyA1g5zt54augc0j2X_ZIJg4ZwAdwPsgzfE")
+        }
+        placesClient = Places.createClient(requireContext())
+
+        setupSearchBar()
+
+        // ImageView 클릭 시 BottomSheet 닫기
+        binding.imageViewPlaceBottomSheetClose.setOnClickListener {
+            dismiss()  // BottomSheetDialogFragment의 dismiss() 메서드를 호출하여 바텀 시트를 닫음
+        }
+    }
+
+    private fun setupSearchBar() {
+        val adapter = PlaceSearchResultsAdapter(mutableListOf()) { place ->
+            dismiss()  // 바텀 시트 닫기
+        }
+        binding.recyclerViewSearchResults.adapter = adapter
+
+        binding.editTextSearch.addTextChangedListener(object : TextWatcher {
+            override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+                searchPlace(s.toString(), adapter)
+            }
+
+            override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
+            override fun afterTextChanged(s: Editable) {}
+        })
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
+        val dialog = dialog as? BottomSheetDialog
+
+        dialog?.let {
+            val bottomSheet = dialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) as FrameLayout
+            val bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet)
+            bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+
+            // 바텀 시트의 드래그를 비활성화(x버튼을 눌러야만 닫히고 손으로 잡아끌 수 없음)
+            bottomSheetBehavior.isDraggable = false
+
+            // 화면 높이의 80%로 설정
+            bottomSheet.layoutParams.height = (getScreenHeight() * 0.85).toInt()
+        }
+    }
+
+    private fun getScreenHeight(): Int {
+        val displayMetrics = DisplayMetrics()
+        requireActivity().windowManager.defaultDisplay.getMetrics(displayMetrics)
+        return displayMetrics.heightPixels
+    }
+
+    private fun searchPlace(query: String, adapter: PlaceSearchResultsAdapter) {
+        val token = AutocompleteSessionToken.newInstance()
+        val request = FindAutocompletePredictionsRequest.builder()
+            .setSessionToken(token)
+            .setQuery(query)
+            .build()
+
+        placesClient.findAutocompletePredictions(request).addOnSuccessListener { response ->
+            val places = response.autocompletePredictions.map { prediction ->
+                SimplePlace(
+                    id = prediction.placeId,
+                    name = prediction.getPrimaryText(null).toString(),
+                    address = prediction.getSecondaryText(null).toString()
+                )
+            }
+            if (places.isNotEmpty()) {
+                adapter.updateItems(places)
+                binding.recyclerViewSearchResults.visibility = View.VISIBLE
+                binding.LayoutPlaceBlank.visibility = View.GONE
+            } else {
+                binding.recyclerViewSearchResults.visibility = View.GONE
+                binding.LayoutPlaceBlank.visibility = View.VISIBLE
+            }
+            Log.d("SearchResults", "Found ${places.size} places")
+        }.addOnFailureListener { exception ->
+            binding.recyclerViewSearchResults.visibility = View.GONE
+            binding.LayoutPlaceBlank.visibility = View.VISIBLE
+            Log.e("SearchResults", "Error retrieving places: ${exception.localizedMessage}")
+        }
+    }
+
+
+}

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/PlaceBottomSheetFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/PlaceBottomSheetFragment.kt
@@ -22,6 +22,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentPlaceBottomSheetBinding
 import kr.co.lion.modigm.ui.detail.adapter.PlaceSearchResultsAdapter
+import kr.co.lion.modigm.BuildConfig
 
 data class SimplePlace(
     val id: String,
@@ -46,12 +47,13 @@ class PlaceBottomSheetFragment : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
         // bottomSheet 배경 설정
         view.background =
             ContextCompat.getDrawable(requireContext(), R.drawable.style_bottom_sheet_background)
 
         if (!Places.isInitialized()) {
-            Places.initialize(requireContext(), "AIzaSyCvwwUD0SngnM5gAhvdStSatfMHf03WvsI")
+            Places.initialize(requireContext(), BuildConfig.PLACE_API_KEY)
         }
         placesClient = Places.createClient(requireContext())
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/PlaceBottomSheetFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/PlaceBottomSheetFragment.kt
@@ -51,7 +51,7 @@ class PlaceBottomSheetFragment : BottomSheetDialogFragment() {
             ContextCompat.getDrawable(requireContext(), R.drawable.style_bottom_sheet_background)
 
         if (!Places.isInitialized()) {
-            Places.initialize(requireContext(), "AIzaSyA1g5zt54augc0j2X_ZIJg4ZwAdwPsgzfE")
+            Places.initialize(requireContext(), "AIzaSyCvwwUD0SngnM5gAhvdStSatfMHf03WvsI")
         }
         placesClient = Places.createClient(requireContext())
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/PlaceSearchResultsAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/PlaceSearchResultsAdapter.kt
@@ -1,0 +1,42 @@
+package kr.co.lion.modigm.ui.detail.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.modigm.R
+import kr.co.lion.modigm.ui.detail.SimplePlace
+
+class PlaceSearchResultsAdapter(
+private var items: MutableList<SimplePlace>,
+private val onItemClick: (SimplePlace) -> Unit // 클릭 이벤트를 위한 콜백 함수
+) : RecyclerView.Adapter<PlaceSearchResultsAdapter.ViewHolder>() {
+
+    inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val textViewName: TextView = view.findViewById(R.id.textViewPlaceName)
+        val textViewAddress: TextView = view.findViewById(R.id.textViewPlaceAddress)
+        fun bind(place: SimplePlace, clickListener: (SimplePlace) -> Unit) {
+            textViewName.text = place.name
+            textViewAddress.text = place.address
+            itemView.setOnClickListener { clickListener(place) }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.row_place, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(items[position], onItemClick)
+    }
+
+    override fun getItemCount():Int = items.size
+
+    fun updateItems(newItems: List<SimplePlace>) {
+        items.clear()
+        items.addAll(newItems)
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/main/res/drawable/icon_maps_location_24px.xml
+++ b/app/src/main/res/drawable/icon_maps_location_24px.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M22,10V9.217C22,7.277 22,6.308 21.414,5.705C20.828,5.103 19.886,5.103 18,5.103H15.921C15.004,5.103 14.996,5.101 14.171,4.688L10.84,3.021C9.449,2.325 8.753,1.977 8.012,2.001C7.271,2.025 6.6,2.418 5.253,3.204L4.026,3.92C3.037,4.497 2.543,4.786 2.272,5.266C2,5.746 2,6.33 2,7.499V15.716C2,17.251 2,18.019 2.342,18.446C2.57,18.731 2.889,18.922 3.242,18.986C3.772,19.081 4.422,18.702 5.72,17.944C6.602,17.429 7.45,16.894 8.505,17.039C9.389,17.161 10.21,17.719 11,18.114M8,2V17M15,5V9.5"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M17.5,16.5H17.509M18.308,21.684C18.088,21.888 17.8,22.001 17.5,22C17.198,22 16.909,21.887 16.692,21.683C14.706,19.813 12.046,17.723 13.343,14.69C14.045,13.05 15.73,12 17.5,12C19.27,12 20.956,13.05 21.657,14.69C22.953,17.72 20.299,19.821 18.308,21.684Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/fragment_detail_edit.xml
+++ b/app/src/main/res/layout/fragment_detail_edit.xml
@@ -173,7 +173,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="20dp"
-                        android:text="스터디 진행에 필요한 기술 스텍을 선택해주세요"
+                        android:text="스터디 진행에 필요한 기술 스택을 선택해주세요"
                         android:textSize="18dp"
                         android:textStyle="bold" />
 

--- a/app/src/main/res/layout/fragment_place_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_place_bottom_sheet.xml
@@ -1,0 +1,69 @@
+<!--<?xml version="1.0" encoding="utf-8"?>-->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp">
+        <ImageView
+            android:id="@+id/imageViewPlaceBottomSheetClose"
+            android:layout_marginTop="20dp"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="end"
+            app:tint="@color/black"
+            android:src="@drawable/icon_close_24"/>
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_marginTop="16dp"
+            android:id="@+id/textInputLayoutSearch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:endIconMode="clear_text"
+            app:hintEnabled="false"
+            app:startIconDrawable="@drawable/icon_search_24px"
+            android:textSize="16dp"
+            app:hintAnimationEnabled="false">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextSearch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="장소 검색"
+                android:textSize="16dp"
+                android:inputType="text"
+                android:imeOptions="actionSearch"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewSearchResults"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+
+        <LinearLayout
+            android:id="@+id/LayoutPlaceBlank"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="40dp"
+            android:orientation="vertical"
+            android:gravity="center">
+            <ImageView
+                android:layout_width="80dp"
+                android:layout_height="80dp"
+                android:src="@drawable/icon_maps_location_24px"
+                app:tint="@color/textGray"
+                android:layout_marginTop="100dp"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="진행할 장소를 선택해주세요"
+                android:textColor="@color/textGray"
+                android:textSize="18dp"/>
+        </LinearLayout>
+
+    </LinearLayout>
+
+</layout>

--- a/app/src/main/res/layout/fragment_skill_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_skill_bottom_sheet.xml
@@ -33,7 +33,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="기술스텍"
+                android:text="기술스택"
                 android:textSize="18dp"
                 android:textStyle="bold" />
 

--- a/app/src/main/res/layout/row_place.xml
+++ b/app/src/main/res/layout/row_place.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/textViewPlaceName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:textSize="16dp" />
+
+    <TextView
+        android:id="@+id/textViewPlaceAddress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="#666"
+        android:textSize="14dp" />
+
+</LinearLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #104

## 📝작업 내용

> Google 장소 api 사용

> 게시글 수정화면에서 장소 입력 창을 누르면 바텀시트를 보여주고 원하는 장소를 검색해 리스트 항목을 누르면 해당 장소의 이름이 보이게 구현 했습니다.

> 사진은 아래 기술 스택 text 수정 전에 캡쳐한 사진입니다.

> 커밋 메시지에 이슈 번호 틀렸는데 죄송합니다...ㅎㅎ

> 아무생각없이 api key 입력한채로 push했다가 다시 수정했습니다 api키는 삭재 후 재생성 해서 바꿔놨어요 ㅠ

### 스크린샷 (선택)
|장소 검색화면 | 장소검색 리스트 | 장소 선택 |
|--|--|--|
<image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/76bf5ab3-f06f-4c3a-8604-a012f9894415" width=250 /> | <image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/8f06b8b9-dbbd-4c7a-8730-6474de132aad" width=250 />| <image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/3a6e5068-87fe-421b-857f-2fb9aec006e8" width=250 /> |

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 장소 검색 후 선택하면 장소 이름이 글 수정 화면에 보이는데 장소 입력 창 아래에 textview배치해서 상세주소를 가져오는게 좋을까요? 

> 장소 검색 화면의 이미지 및 글씨의 크기 및 색상
