### PR TITLE
[#114] feature 이메일 sns 계정에 따른 회원가입 절차 분기

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -39,6 +39,10 @@ class JoinFragment : Fragment() {
     private val joinType: JoinType? by lazy {
         JoinType.getType(arguments?.getString("joinType")?:"")
     }
+
+    private val customToken: String? by lazy {
+        arguments?.getString("customToken")
+    }
 //    var joinType = "email"
 
     override fun onCreateView(
@@ -302,7 +306,7 @@ class JoinFragment : Fragment() {
         lifecycleScope.launch {
             when(joinType){
                 JoinType.EMAIL -> viewModel.completeJoinEmailUser()
-                JoinType.KAKAO -> viewModel.completeJoinSnsUser()
+                JoinType.KAKAO -> customToken?.let { viewModel.completeJoinSnsUser(it) }
                 else -> {}
             }
         }

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -26,6 +26,7 @@ import kr.co.lion.modigm.ui.join.vm.JoinStep3ViewModel
 import kr.co.lion.modigm.ui.join.vm.JoinViewModel
 import kr.co.lion.modigm.ui.study.StudyFragment
 import kr.co.lion.modigm.util.FragmentName
+import kr.co.lion.modigm.util.JoinType
 
 class JoinFragment : Fragment() {
 
@@ -36,10 +37,10 @@ class JoinFragment : Fragment() {
     private val viewModelStep2: JoinStep2ViewModel by activityViewModels()
     private val viewModelStep3: JoinStep3ViewModel by activityViewModels()
 
-//    private val joinType: String by lazy {
-//        arguments?.getString("joinType").toString()
-//    }
-    var joinType = "email"
+    private val joinType: JoinType? by lazy {
+        JoinType.getType(arguments?.getString("joinType")?:"")
+    }
+//    var joinType = "email"
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -127,13 +128,27 @@ class JoinFragment : Fragment() {
     private fun settingViewPagerAdapter(){
         val viewPagerAdapter = JoinViewPagerAdapter(this)
 
-        viewPagerAdapter.addFragments(
-            arrayListOf(
-                JoinStep1Fragment(),
-                JoinStep2Fragment(),
-                JoinStep3Fragment()
-            )
-        )
+        when(joinType){
+            // 이메일로 회원가입할 때
+            JoinType.EMAIL -> {
+                viewPagerAdapter.addFragments(
+                    arrayListOf(
+                        JoinStep1Fragment(),
+                        JoinStep2Fragment(),
+                        JoinStep3Fragment()
+                    )
+                )
+            }
+            // SNS계정으로 회원가입할 때
+            else -> {
+                viewPagerAdapter.addFragments(
+                    arrayListOf(
+                        JoinStep2Fragment(),
+                        JoinStep3Fragment()
+                    )
+                )
+            }
+        }
 
         with(binding){
             // 어댑터 설정
@@ -157,15 +172,29 @@ class JoinFragment : Fragment() {
             // 다음 버튼 클릭 시 다음 화면으로 넘어가기
             buttonJoinNext.setOnClickListener {
 
-                // 화면별로 유효성 검사 먼저 하고
-                when(viewPagerJoin.currentItem){
-                    // 이메일, 비밀번호 화면
-                    0 -> step1Process()
-                    // 이름, 전화번호 인증 화면
-                    1 -> step2Process()
-                    // 관심 분야 선택 화면
-                    2 -> step3Process()
+                when(joinType){
+                    // 이메일로 회원가입할 때
+                    JoinType.EMAIL -> {
+                        when(viewPagerJoin.currentItem){
+                            // 이메일, 비밀번호 화면
+                            0 -> step1Process()
+                            // 이름, 전화번호 인증 화면
+                            1 -> step2Process()
+                            // 관심 분야 선택 화면
+                            2 -> step3Process()
+                        }
+                    }
+                    // SNS계정으로 회원가입할 때
+                    else -> {
+                        when(viewPagerJoin.currentItem){
+                            // 이름, 전화번호 인증 화면
+                            0 -> step2Process()
+                            // 관심 분야 선택 화면
+                            1 -> step3Process()
+                        }
+                    }
                 }
+
             }
         }
 
@@ -276,8 +305,9 @@ class JoinFragment : Fragment() {
 
         lifecycleScope.launch {
             when(joinType){
-                "email" -> viewModel.completeJoinEmailUser()
-                "phone" -> viewModel.completeJoinSnsUser()
+                JoinType.EMAIL -> viewModel.completeJoinEmailUser()
+                JoinType.KAKAO -> viewModel.completeJoinSnsUser()
+                else -> {}
             }
         }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -5,7 +5,6 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowManager
 import android.widget.TextView
 import androidx.activity.addCallback
 import androidx.fragment.app.FragmentManager
@@ -47,9 +46,6 @@ class JoinFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-
-        // 키보드가 올려올때 다음 버튼이 같이 올라와 텍스트필드를 막는 부분을 아래 코드로 셋팅하여 다음 버튼이 가려지게 함
-        requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
 
         binding = FragmentJoinBinding.inflate(inflater)
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
@@ -114,7 +114,7 @@ class JoinViewModel : ViewModel() {
         return user
     }
 
-    // 회원가입 완료 전에 이메일(SNS) 계정과 전화번호 계정을 통합
+    // 회원가입 완료 전에 이메일 계정과 전화번호 계정을 통합
     private fun linkEmailAndPhone(){
         _auth.signInWithEmailAndPassword(_email.value!!, _password.value!!).addOnCompleteListener { loginTask ->
             if(loginTask.isSuccessful){
@@ -142,13 +142,28 @@ class JoinViewModel : ViewModel() {
         _joinCompleted.value = true
     }
 
+    // 회원가입 완료 전에 SNS 계정과 전화번호 계정을 통합
+    private fun linkSnsAndPhone(customToken: String){
+        _auth.signInWithCustomToken(customToken).addOnCompleteListener { loginTask ->
+            if(loginTask.isSuccessful){
+                _auth.currentUser?.linkWithCredential(_phoneCredential.value!!)?.addOnCompleteListener { linkTask ->
+                    if(!linkTask.isSuccessful){
+                        Log.d("testError", "linkWithCredential : ${linkTask.exception}")
+                    }
+                }
+            }else{
+                Log.d("testError", "signInWithCustomToken : ${loginTask.exception}")
+            }
+        }
+    }
+
     // SNS 계정 회원 가입 완료
-    fun completeJoinSnsUser(){
+    fun completeJoinSnsUser(customToken: String){
         // UserInfoData 객체 생성
         val user = createUserInfoData()
 
         // SNS 계정과 전화번호 계정을 연결
-
+        linkSnsAndPhone(customToken)
         // 파이어 스토어에 저장
         viewModelScope.launch {
             _userInfoRepository.insetUserData(user)

--- a/app/src/main/java/kr/co/lion/modigm/util/JoinType.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/JoinType.kt
@@ -1,0 +1,19 @@
+package kr.co.lion.modigm.util
+
+import kr.co.lion.modigm.R
+
+enum class JoinType (var provider:String, var icon:Int) {
+    KAKAO("kakao", R.drawable.kakaotalk_sharing_btn_small),
+    EMAIL("email", R.drawable.email_login_logo),
+    ERROR("error", 0);
+
+    companion object{
+        fun getType(str:String):JoinType{
+            return when(str){
+                "kakao" -> KAKAO
+                "email" -> EMAIL
+                else -> ERROR
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_join_step1.xml
+++ b/app/src/main/res/layout/fragment_join_step1.xml
@@ -9,98 +9,104 @@
             type="kr.co.lion.modigm.ui.join.vm.JoinStep1ViewModel" />
     </data>
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:paddingLeft="16dp"
-        android:paddingTop="40dp"
-        android:paddingRight="16dp"
-        android:transitionGroup="true"
-        tools:context=".ui.join.JoinStep1Fragment">
+        android:layout_height="match_parent">
 
-        <TextView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="사용하실 이메일과 \n비밀번호를 입력해주세요"
-            android:textSize="26dp" />
+            android:orientation="vertical"
+            android:paddingLeft="16dp"
+            android:paddingTop="40dp"
+            android:paddingRight="16dp"
+            android:transitionGroup="true"
+            tools:context=".ui.join.JoinStep1Fragment">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="40dp"
-            android:text="이메일"
-            android:textSize="16dp"
-            android:textStyle="bold" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/textInputLayout_join_userEmail"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:endIconMode="clear_text"
-            app:hintAnimationEnabled="false"
-            app:hintEnabled="false">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/textInput_join_userEmail"
+            <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="이메일 입력"
-                android:inputType="text|textEmailAddress"
-                android:textSize="16dp"
-                android:text="@={viewModel.userEmail}" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:text="사용하실 이메일과 \n비밀번호를 입력해주세요"
+                android:textSize="26dp" />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="비밀번호"
-            android:textSize="16dp"
-            android:textStyle="bold" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/textInputLayout_join_userPassword"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:endIconMode="password_toggle"
-            app:hintAnimationEnabled="false"
-            app:hintEnabled="false">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/textInput_join_userPassword"
+            <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="비밀번호 입력"
-                android:inputType="text|textPassword"
+                android:layout_marginTop="40dp"
+                android:text="이메일"
                 android:textSize="16dp"
-                android:text="@={viewModel.userPassword}" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:textStyle="bold" />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="비밀번호 확인"
-            android:textSize="16dp"
-            android:textStyle="bold" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/textInputLayout_join_userPasswordCheck"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:endIconMode="password_toggle"
-            app:hintAnimationEnabled="false"
-            app:hintEnabled="false">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/textInput_join_userPasswordCheck"
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/textInputLayout_join_userEmail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="비밀번호 확인 입력"
-                android:inputType="text|textPassword"
+                app:endIconMode="clear_text"
+                app:hintAnimationEnabled="false"
+                app:hintEnabled="false">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/textInput_join_userEmail"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="이메일 입력"
+                    android:inputType="text|textEmailAddress"
+                    android:text="@={viewModel.userEmail}"
+                    android:textSize="16dp" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="비밀번호"
                 android:textSize="16dp"
-                android:text="@={viewModel.userPasswordCheck}" />
-        </com.google.android.material.textfield.TextInputLayout>
-    </LinearLayout>
+                android:textStyle="bold" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/textInputLayout_join_userPassword"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:endIconMode="password_toggle"
+                app:hintAnimationEnabled="false"
+                app:hintEnabled="false">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/textInput_join_userPassword"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="비밀번호 입력"
+                    android:inputType="text|textPassword"
+                    android:text="@={viewModel.userPassword}"
+                    android:textSize="16dp" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="비밀번호 확인"
+                android:textSize="16dp"
+                android:textStyle="bold" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/textInputLayout_join_userPasswordCheck"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:endIconMode="password_toggle"
+                app:hintAnimationEnabled="false"
+                app:hintEnabled="false">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/textInput_join_userPasswordCheck"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="비밀번호 확인 입력"
+                    android:inputType="text|textPassword"
+                    android:text="@={viewModel.userPasswordCheck}"
+                    android:textSize="16dp" />
+            </com.google.android.material.textfield.TextInputLayout>
+        </LinearLayout>
+    </ScrollView>
+
 </layout>

--- a/app/src/main/res/layout/fragment_join_step2.xml
+++ b/app/src/main/res/layout/fragment_join_step2.xml
@@ -9,109 +9,36 @@
             type="kr.co.lion.modigm.ui.join.vm.JoinStep2ViewModel" />
     </data>
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:paddingLeft="16dp"
-        android:paddingTop="40dp"
-        android:paddingRight="16dp"
-        android:transitionGroup="true"
-        tools:context=".ui.join.JoinStep2Fragment">
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="이름과 전화번호를 \n입력해주세요"
-            android:textSize="26dp" />
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="40dp"
-            android:text="이름"
-            android:textSize="16dp"
-            android:textStyle="bold" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/textInputLayout_join_userName"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:endIconMode="clear_text"
-            app:hintAnimationEnabled="false"
-            app:hintEnabled="false">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/textinput_join_userName"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="이름 입력"
-                android:inputType="text|textEmailAddress"
-                android:textSize="16dp"
-                android:text="@={viewModel.userName}" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="전화번호"
-            android:textSize="16dp"
-            android:textStyle="bold" />
+        android:layout_height="match_parent">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/textInputLayout_join_userPhone"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                app:endIconMode="clear_text"
-                app:hintAnimationEnabled="false"
-                app:hintEnabled="false">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/textinput_join_userPhone"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="전화번호 입력"
-                    android:inputType="phone"
-                    android:textSize="16dp"
-                    android:text="@={viewModel.userPhone}" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <Button
-                android:id="@+id/button_join_phoneAuth"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="10dp"
-                android:layout_weight="1"
-                android:text="인증하기"
-                android:textSize="14dp"
-                android:textStyle="bold" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/linearLayout_join_phoneAuth"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
             android:orientation="vertical"
-            android:visibility="gone"
-            tools:visibility="visible">
+            android:paddingLeft="16dp"
+            android:paddingTop="40dp"
+            android:paddingRight="16dp"
+            android:transitionGroup="true"
+            tools:context=".ui.join.JoinStep2Fragment">
 
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="인증번호 확인"
+                android:text="이름과 전화번호를 \n입력해주세요"
+                android:textSize="26dp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="40dp"
+                android:text="이름"
                 android:textSize="16dp"
                 android:textStyle="bold" />
 
             <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/textInputLayout_join_phoneAuth"
+                android:id="@+id/textInputLayout_join_userName"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:endIconMode="clear_text"
@@ -119,15 +46,94 @@
                 app:hintEnabled="false">
 
                 <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/textinput_join_phoneAuth"
+                    android:id="@+id/textinput_join_userName"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="인증번호 입력"
-                    android:inputType="text"
-                    android:textSize="16dp"
-                    android:text="@={viewModel.inputSmsCode}" />
+                    android:hint="이름 입력"
+                    android:inputType="text|textEmailAddress"
+                    android:text="@={viewModel.userName}"
+                    android:textSize="16dp" />
             </com.google.android.material.textfield.TextInputLayout>
-        </LinearLayout>
 
-    </LinearLayout>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="전화번호"
+                android:textSize="16dp"
+                android:textStyle="bold" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/textInputLayout_join_userPhone"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    app:endIconMode="clear_text"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="false">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/textinput_join_userPhone"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="전화번호 입력"
+                        android:inputType="phone"
+                        android:text="@={viewModel.userPhone}"
+                        android:textSize="16dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Button
+                    android:id="@+id/button_join_phoneAuth"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="10dp"
+                    android:layout_weight="1"
+                    android:text="인증하기"
+                    android:textSize="14dp"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/linearLayout_join_phoneAuth"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="인증번호 확인"
+                    android:textSize="16dp"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/textInputLayout_join_phoneAuth"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:endIconMode="clear_text"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="false">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/textinput_join_phoneAuth"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="인증번호 입력"
+                        android:inputType="text"
+                        android:text="@={viewModel.inputSmsCode}"
+                        android:textSize="16dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
+
+        </LinearLayout>
+    </ScrollView>
+
 </layout>

--- a/app/src/main/res/layout/fragment_join_step3.xml
+++ b/app/src/main/res/layout/fragment_join_step3.xml
@@ -11,30 +11,41 @@
     android:transitionGroup="true"
     tools:context=".ui.join.JoinStep3Fragment">
 
-    <TextView
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="관심있는 분야를 \n선택해주세요"
-        android:textSize="26dp" />
+        android:layout_height="match_parent">
 
-    <Space
-        android:layout_width="match_parent"
-        android:layout_height="40dp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/textView_join_alert"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="관심있는 분야를 선택해주세요"
-        android:textColor="#FF0000"
-        android:visibility="gone"
-        tools:visibility="visible" />
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="관심있는 분야를 \n선택해주세요"
+                android:textSize="26dp" />
 
-    <com.google.android.material.chip.ChipGroup
-        android:id="@+id/chipGroup_join_interest"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:chipSpacingHorizontal="12dp"
-        app:chipSpacingVertical="8dp" />
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="40dp" />
+
+            <TextView
+                android:id="@+id/textView_join_alert"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="관심있는 분야를 선택해주세요"
+                android:textColor="#FF0000"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/chipGroup_join_interest"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:chipSpacingHorizontal="12dp"
+                app:chipSpacingVertical="8dp" />
+        </LinearLayout>
+    </ScrollView>
 
 </LinearLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #114 

## 📝작업 내용

> SNS계정으로 회원가입 시 전화번호 입력 화면부터 진행할 수 있도록 작업했습니다.
> 아직 SNS 로그인 기능이 미구현단계라서 실제 등록은 안되는 상태입니다.
> 추후 로그인과 회원가입 연결 시 SNS계정 로그인 후 커스텀 토큰과 로그인 타입을 번들에 담아서 JoinFragment에 전달해주시면 됩니다. (SNS 로그인 시 파이어베이스 인증과 연동하는 부분을 아직 몰라서 커스텀 토큰을 받는게 맞는지 다른 걸 받아야하는건지는 추후에 작업하면서 수정해보겠습니다)
>  키보드가 텍스트필드를 가리는 부분은 레이아웃에 스크롤뷰를 추가하는 방식으로 수정했습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
