### PR TITLE
[Feature #113] 찜 화면 구현

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/like/LikeFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/like/LikeFragment.kt
@@ -5,56 +5,104 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.LinearLayoutManager
 import kr.co.lion.modigm.R
+import kr.co.lion.modigm.databinding.FragmentLikeBinding
+import kr.co.lion.modigm.model.StudyData
+import kr.co.lion.modigm.ui.like.adapter.LikeAdapter
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [LikeFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class LikeFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
-        }
-    }
+    private lateinit var binding: FragmentLikeBinding
 
+    // 프래그먼트의 뷰가 생성될 때 호출
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_like, container, false)
+        binding = FragmentLikeBinding.inflate(inflater, container, false)
+
+        return binding.root
+
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment LikeFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            LikeFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
-            }
+    // 뷰가 생성된 직후 호출
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // 툴바 설정
+        settingToolbar()
+
+        setupRecyclerView()
     }
+
+    fun settingToolbar() {
+        binding.toolBarLike.title = "찜한 스터디"
+    }
+
+    fun setupRecyclerView() {
+        // 비어있는 화면 확인 임시 데이터
+//        val dummyData = listOf<StudyData>()
+
+        // 임시 확인 데이터 (StudyData 기반으로)
+        val dummyData = listOf(
+            StudyData(
+                studyIdx = 1,
+                studyTitle = "Java 스터디 모집합니다!",
+                studyContent = "자바 기초부터 시작하는 스터디",
+                studyType = 0,
+                studyPeriod = 12,
+                studyOnOffline = 0,
+                studyPlace = "서울",
+                studyApplyMethod = 1,
+                studyMaxMember = 20,
+                studySkillList = listOf(1, 2),
+                studyState = true,
+                studyPic = "image_detail_1",
+                studyUidList = listOf("1", "2", "3")
+            ),
+            StudyData(
+                studyIdx = 2,
+                studyTitle = "Python 스터디 모집합니다!",
+                studyContent = "데이터 사이언스를 위한 파이썬",
+                studyType = 1,
+                studyPeriod = 10,
+                studyOnOffline = 1,
+                studyPlace = "온라인",
+                studyApplyMethod = 0,
+                studyMaxMember = 10,
+                studySkillList = listOf(3, 4),
+                studyState = false,
+                studyPic = "image_detail_2",
+                studyUidList = listOf("4","5")
+            ),
+            StudyData(
+                studyIdx = 3,
+                studyTitle = "JavaScript 프로젝트!",
+                studyContent = "웹 개발 프로젝트 참가자 모집",
+                studyType = 2,
+                studyPeriod = 15,
+                studyOnOffline = 2,
+                studyPlace = "온오프 혼합",
+                studyApplyMethod = 1,
+                studyMaxMember = 15,
+                studySkillList = listOf(5, 6),
+                studyState = true,
+                studyPic = "image_detail_1",
+                studyUidList = listOf("6", "7", "8", "9", "10")
+            )
+        )
+
+        if (dummyData.isNotEmpty()) {
+            binding.recyclerviewLike.visibility = View.VISIBLE
+            binding.blankLayoutLike.visibility = View.GONE
+            binding.recyclerviewLike.layoutManager = LinearLayoutManager(context)
+            binding.recyclerviewLike.adapter = LikeAdapter(dummyData)
+        } else {
+            binding.recyclerviewLike.visibility = View.GONE
+            binding.blankLayoutLike.visibility = View.VISIBLE
+        }
+    }
+
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/like/LikeFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/like/LikeFragment.kt
@@ -45,7 +45,7 @@ class LikeFragment : Fragment() {
         // 비어있는 화면 확인 임시 데이터
 //        val dummyData = listOf<StudyData>()
 
-        // 임시 확인 데이터 (StudyData 기반으로)
+        // 임시 확인 데이터
         val dummyData = listOf(
             StudyData(
                 studyIdx = 1,

--- a/app/src/main/java/kr/co/lion/modigm/ui/like/adapter/LikeAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/like/adapter/LikeAdapter.kt
@@ -1,0 +1,95 @@
+package kr.co.lion.modigm.ui.like.adapter
+
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.modigm.R
+import kr.co.lion.modigm.databinding.RowLikeBinding
+import kr.co.lion.modigm.model.StudyData
+
+class LikeAdapter(private val studyList: List<StudyData>) : RecyclerView.Adapter<LikeAdapter.StudyViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StudyViewHolder {
+        val binding = RowLikeBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return StudyViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: StudyViewHolder, position: Int) {
+        holder.bind(studyList[position])
+    }
+
+    override fun getItemCount(): Int = studyList.size
+
+
+
+    inner class StudyViewHolder(private val binding: RowLikeBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(study: StudyData) {
+            binding.apply {
+
+                imageViewLikeCover.setImageResource(R.drawable.image_detail_1)
+
+                // 모집 상태에 따라 텍스트와 색상 설정
+                textViewLikeState.text = if (study.studyState) "모집 중" else "모집 마감"
+                val textColor = if (study.studyState) ContextCompat.getColor(itemView.context, R.color.pointColor)
+                else ContextCompat.getColor(itemView.context, R.color.dividerView)
+                textViewLikeState.setTextColor(textColor)
+
+                // 스터디 진행 방식
+                textViewLikeStateMeet.text = when (study.studyOnOffline) {
+                    0 -> "오프라인"
+                    1 -> "온라인"
+                    else -> "온오프혼합"
+                }
+
+                // 모집 상태에 따라 진행 방식 텍스트 색상 설정
+                textViewLikeStateMeet.setTextColor(
+                    if (study.studyState) {
+                        when (study.studyOnOffline) {
+                            0 -> Color.parseColor("#EB9C58") // 오프라인 색상
+                            1 -> Color.parseColor("#0FA981") // 온라인 색상
+                            else -> Color.parseColor("#0096FF") // 온오프혼합 색상
+                        }
+                    } else {
+                        ContextCompat.getColor(itemView.context, R.color.dividerView) // 모집 종료 시 회색
+                    }
+                )
+
+                // 스터디 제목
+                textViewLikeTitle.text = study.studyTitle
+
+                // 스터디 종류
+                textViewLikeStatePeriod.apply {
+                    text = when (study.studyType) {
+                        0 -> "스터디"
+                        1 -> "프로젝트"
+                        else -> "공모전"
+                    }
+                }
+                // 스터디 신청 인원
+                textViewLikeJoinMember.text = study.studyUidList.size.toString()
+
+                // 스터디 최대 인원
+                textViewLikeTotalMember.text = study.studyMaxMember.toString()
+
+                // 스터디 종류에 따라 아이콘 변경
+                imageViewLikeStatePeriod.setImageResource(
+                    when (study.studyType) {
+                        0 -> R.drawable.icon_closed_book_24px
+                        1 -> R.drawable.icon_code_box_24px
+                        else -> R.drawable.icon_trophy_24px
+                    }
+                )
+
+                // 스터디 신청 방식에 따른 텍스트 설정
+                textViewLikeApplyType.text = when (study.studyApplyMethod) {
+                    0 -> "신청제"
+                    1 -> "선착순"
+                    else -> "기타"
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/kr/co/lion/modigm/ui/like/adapter/LikeAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/like/adapter/LikeAdapter.kt
@@ -22,8 +22,6 @@ class LikeAdapter(private val studyList: List<StudyData>) : RecyclerView.Adapter
 
     override fun getItemCount(): Int = studyList.size
 
-
-
     inner class StudyViewHolder(private val binding: RowLikeBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(study: StudyData) {
             binding.apply {

--- a/app/src/main/res/layout/fragment_like.xml
+++ b/app/src/main/res/layout/fragment_like.xml
@@ -1,14 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
     tools:context=".ui.like.LikeFragment">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolBarLike"
+        style="@style/CustomToolbar"
+        android:elevation="4dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="?attr/actionBarTheme"
+        app:titleTextAppearance="@style/toolbarText" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerviewLike"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"/>
+
+    <LinearLayout
+        android:id="@+id/blankLayoutLike"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        android:orientation="vertical"
+        android:visibility="gone"
+        tools:visibility="visible">
 
-</FrameLayout>
+        <ImageView
+            android:layout_width="70dp"
+            android:layout_height="70dp"
+            android:layout_gravity="center"
+            android:layout_marginTop="200dp"
+            app:tint="#ccc"
+            android:src="@drawable/icon_book_24px" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="20dp"
+            android:textColor="@color/textGray"
+            android:text="찜한 스터디 내역이 없어요"
+            android:textSize="18dp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/row_like.xml
+++ b/app/src/main/res/layout/row_like.xml
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:backgroundTint="@color/cardview_light_background"
+        app:cardElevation="2dp"
+        app:strokeWidth="0dp"
+        android:layout_marginVertical="10dp"
+        android:layout_marginHorizontal="16dp">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:padding="16dp">
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:strokeWidth="0dp"
+                android:elevation="0dp">
+                <ImageView
+                    android:id="@+id/imageViewLikeCover"
+                    android:layout_width="80dp"
+                    android:layout_height="80dp"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/image_detail_2"/>
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:layout_weight="1"
+                android:layout_marginLeft="10dp">
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+                    <TextView
+                        android:id="@+id/textViewLikeState"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="4dp"
+                        android:layout_gravity="center"
+                        android:textStyle="bold"
+                        android:text="모집중"
+                        android:textColor="@color/pointColor"
+                        android:textSize="14dp"/>
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="4dp"
+                        android:text="·"
+                        android:textColor="@color/textGray"
+                        android:textStyle="bold"
+                        android:textSize="20dp"/>
+                    <TextView
+                        android:id="@+id/textViewLikeStateMeet"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:textStyle="bold"
+                        android:text="온라인"
+                        android:textColor="#0FA981"
+                        android:textSize="14dp"/>
+                </LinearLayout>
+                <TextView
+                    android:id="@+id/textViewLikeTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="20dp"
+                    android:text="Kotlin 스터디 모집합니다!dddddddddd"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:textStyle="bold"
+                    android:textSize="18dp"/>
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="horizontal">
+                    <ImageView
+                        android:id="@+id/imageViewLikeStatePeriod"
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:layout_gravity="center"
+                        app:tint="@color/textGray"
+                        android:src="@drawable/icon_clock_24px"
+                        />
+                    <TextView
+                        android:id="@+id/textViewLikeStatePeriod"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:paddingHorizontal="2dp"
+                        android:text="스터디"
+                        android:textColor="@color/textGray"
+                        android:textSize="14dp"/>
+                    <ImageView
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:layout_gravity="center"
+                        android:textColor="@color/textGray"
+                        app:tint="@color/textGray"
+                        android:src="@drawable/icon_group_24px"
+                        />
+                    <TextView
+                        android:id="@+id/textViewLikeJoinMember"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="4dp"
+                        android:layout_gravity="center"
+                        android:textColor="@color/textGray"
+                        android:text="1"
+                        android:textSize="14dp" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="2dp"
+                        android:textColor="@color/textGray"
+                        android:layout_gravity="center"
+                        android:text="/"
+                        android:textSize="16dp" />
+
+                    <TextView
+                        android:id="@+id/textViewLikeTotalMember"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="2dp"
+                        android:textColor="@color/textGray"
+                        android:layout_gravity="center"
+                        android:text="20"
+                        android:textSize="14dp" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="4dp"
+                        android:textColor="@color/textGray"
+                        android:layout_gravity="center"
+                        android:text="명"
+                        android:textSize="14dp" />
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="2dp"
+                        android:textColor="@color/textGray"
+                        android:layout_gravity="center"
+                        android:text="("
+                        android:textSize="14dp" />
+
+                    <TextView
+                        android:id="@+id/textViewLikeApplyType"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="2dp"
+                        android:textColor="@color/textGray"
+                        android:layout_gravity="center"
+                        android:text="신청제"
+                        android:textSize="14dp" />
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="2dp"
+                        android:textColor="@color/textGray"
+                        android:layout_gravity="center"
+                        android:text=")"
+                        android:textSize="14dp" />
+                    <ImageView
+                        android:id="@+id/imageViewLikeHeart"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:src="@drawable/icon_favorite_24px"
+                        app:tint="@color/pointColor"/>
+
+
+                </LinearLayout>
+
+
+            </LinearLayout>
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+</LinearLayout>

--- a/app/src/main/res/layout/row_like.xml
+++ b/app/src/main/res/layout/row_like.xml
@@ -23,7 +23,7 @@
                 android:layout_height="wrap_content"
                 app:strokeWidth="0dp"
                 android:elevation="0dp">
-                <ImageView
+                <com.google.android.material.imageview.ShapeableImageView
                     android:id="@+id/imageViewLikeCover"
                     android:layout_width="80dp"
                     android:layout_height="80dp"
@@ -42,7 +42,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/textViewLikeState"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -52,15 +52,15 @@
                         android:text="모집중"
                         android:textColor="@color/pointColor"
                         android:textSize="14dp"/>
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginEnd="4dp"
                         android:text="·"
-                        android:textColor="@color/textGray"
+                        android:textColor="@color/dividerView"
                         android:textStyle="bold"
                         android:textSize="20dp"/>
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/textViewLikeStateMeet"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -70,7 +70,7 @@
                         android:textColor="#0FA981"
                         android:textSize="14dp"/>
                 </LinearLayout>
-                <TextView
+                <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/textViewLikeTitle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -94,7 +94,7 @@
                         app:tint="@color/textGray"
                         android:src="@drawable/icon_clock_24px"
                         />
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/textViewLikeStatePeriod"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -111,7 +111,7 @@
                         app:tint="@color/textGray"
                         android:src="@drawable/icon_group_24px"
                         />
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/textViewLikeJoinMember"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -121,7 +121,7 @@
                         android:text="1"
                         android:textSize="14dp" />
 
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="2dp"
@@ -130,7 +130,7 @@
                         android:text="/"
                         android:textSize="16dp" />
 
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/textViewLikeTotalMember"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -140,7 +140,7 @@
                         android:text="20"
                         android:textSize="14dp" />
 
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="4dp"
@@ -148,7 +148,7 @@
                         android:layout_gravity="center"
                         android:text="명"
                         android:textSize="14dp" />
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="2dp"
@@ -157,7 +157,7 @@
                         android:text="("
                         android:textSize="14dp" />
 
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/textViewLikeApplyType"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -166,7 +166,7 @@
                         android:layout_gravity="center"
                         android:text="신청제"
                         android:textSize="14dp" />
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
@@ -175,7 +175,7 @@
                         android:layout_gravity="center"
                         android:text=")"
                         android:textSize="14dp" />
-                    <ImageView
+                    <com.google.android.material.imageview.ShapeableImageView
                         android:id="@+id/imageViewLikeHeart"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"


### PR DESCRIPTION
## #️⃣연관된 이슈

> #113 

## 📝작업 내용

> 찜 화면 구현

> 하트 아이콘 클릭 이벤트는 DB연결하면서 구현 예정입니다

> 모집 상태가 모집 종료인 경우엔 회색으로 표시되도록 설정해뒀습니다.

> 활동 타입, 진행방식에 따라 text색상 설정 했습니다.

> 일단 깃에는 툴바 그림자 없이 올렸습니다. 첫번째 사진보시면 됩니다

### 스크린샷 (선택)
|찜 화면(툴바 그림자 없음 / 18dp) | 찜 목록 없을 때 화면 (툴바 그림자 있음) |
|--|--|
<image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/a7250340-9a90-4b72-bd42-b2b6861a2dcf" width=250 /> | <image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/5cdb61b4-4f54-4d7f-b58e-0802274a267d" width=250 />|


|제목 글씨 크기 비교( 왼쪽 16dp / 오른쪽 18dp)|
|--|
<image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/d547cd7a-5368-43f5-8013-d142580d1b15" /> | 

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

> 툴바 아래에 그림자 유무 만약 넣는게 괜찮다면 툴바랑 데이터 보이는 공간이랑 구분 안 가는 화면들(홈 제외)에도 넣는게 좋을 거 같습니다

> 제목 text 크기 엄청 큰 차이는 없긴한데 18dp는 제목이 강조되어 보이는 반면에 살짝 큰느낌이 있고 16dp는 강조되는 느낌이 좀 덜해서 리뷰 요청드려요 

> 이외에도 고칠 부분있으면 말씀해주세요!

