### PR TITLE
[#138] feature sns 로그인 시 회원가입 진행

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinDuplicateFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinDuplicateFragment.kt
@@ -59,6 +59,9 @@ class JoinDuplicateFragment : Fragment() {
             JoinType.EMAIL.provider -> {
                 binding.imageViewJoinDupServiceType.setImageResource(JoinType.EMAIL.icon)
             }
+            JoinType.GITHUB.provider -> {
+                binding.imageViewJoinDupServiceType.setImageResource(JoinType.GITHUB.icon)
+            }
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -27,6 +27,7 @@ import kr.co.lion.modigm.ui.join.vm.JoinViewModel
 import kr.co.lion.modigm.ui.study.StudyFragment
 import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.JoinType
+import kr.co.lion.modigm.util.ModigmApplication.Companion.prefs
 import kr.co.lion.modigm.util.hideSoftInput
 
 class JoinFragment : Fragment() {
@@ -358,6 +359,10 @@ class JoinFragment : Fragment() {
         // 회원가입 완료 시 다음 화면으로 이동
         viewModel.joinCompleted.observe(viewLifecycleOwner){
             hideLoading()
+
+            // SharedPreferences에 uid값 저장
+            viewModel.user.value?.let { it1 -> prefs.setString("uid", it1.uid) }
+
             if(it){
                 parentFragmentManager.beginTransaction()
                     .replace(R.id.containerMain, StudyFragment())

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -1,7 +1,7 @@
 package kr.co.lion.modigm.ui.join
 
+import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -15,6 +15,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.firebase.auth.AuthCredential
 import kotlinx.coroutines.launch
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentJoinBinding
@@ -45,6 +46,14 @@ class JoinFragment : Fragment() {
         arguments?.getString("customToken")
     }
 
+    private val credential: AuthCredential? by lazy {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arguments?.getParcelable("credential", AuthCredential::class.java)
+        } else {
+            arguments?.getParcelable("credential")
+        }
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -53,10 +62,24 @@ class JoinFragment : Fragment() {
 
         binding = FragmentJoinBinding.inflate(inflater)
 
+        settingValuesFromBundle()
         settingToolBar()
         settingObservers()
 
         return binding.root
+    }
+
+    // 번들로 전달받은 값들을 뷰모델 라이브 데이터에 셋팅
+    private fun settingValuesFromBundle(){
+        if(customToken != null){
+            viewModel.setSnsCustomToken(customToken!!)
+        }
+        if(credential != null){
+            viewModel.setSnsCredential(credential!!)
+        }
+        if(joinType != null){
+            viewModel.setSnsProvider(joinType?.provider!!)
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -283,17 +306,14 @@ class JoinFragment : Fragment() {
         if(!validation) return
         // 응답값
         viewModelStep3.selectedInterestList.value?.let { it1 ->
-            viewModel.setInterests(
-                it1
-            )
+            viewModel.setInterests(it1)
         }
 
         lifecycleScope.launch {
             showLoading()
             when(joinType){
                 JoinType.EMAIL -> viewModel.completeJoinEmailUser()
-                JoinType.KAKAO -> customToken?.let { viewModel.completeJoinSnsUser(it) }
-                else -> {}
+                else -> viewModel.completeJoinSnsUser()
             }
         }
     }
@@ -331,6 +351,7 @@ class JoinFragment : Fragment() {
                     .replace(R.id.containerMain, joinFragment)
                     .addToBackStack(FragmentName.JOIN_DUPLICATE.str)
                     .commit()
+                viewModel.isPhoneAlreadyRegistered.value = false
             }
         }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
@@ -3,6 +3,7 @@ package kr.co.lion.modigm.ui.join.vm
 import android.app.Activity
 import android.os.CountDownTimer
 import android.text.InputFilter
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -169,9 +170,10 @@ class JoinStep2ViewModel: ViewModel() {
 
                     // 프로바이더 확인
                     for(provider in signInResult.user?.providerData!!){
-                        if(provider.providerId == "password"){
-                            _alreadyRegisteredUserProvider.value = "email"
+                        if(provider.providerId != "firebase" && provider.providerId != "phone"){
+                            _alreadyRegisteredUserProvider.value = provider.providerId
                             _alreadyRegisteredUserEmail.value = provider.email!!
+                            Log.d("test1234", "${provider.providerId}")
                         }
                     }
                     // 중복인 경우에는 이미 등록된 계정을 지우면 안되기 때문에 로그아웃만 하기

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
@@ -3,11 +3,11 @@ package kr.co.lion.modigm.ui.join.vm
 import android.app.Activity
 import android.os.CountDownTimer
 import android.text.InputFilter
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.google.firebase.FirebaseException
+import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthException
 import com.google.firebase.auth.PhoneAuthCredential
@@ -125,8 +125,8 @@ class JoinStep2ViewModel: ViewModel() {
     val errorMessage: LiveData<String> = _errorMessage
 
     // 나중에 이메일 계정과 합칠 때 필요한 전화번호 인증 credential
-    private var _credential = MutableLiveData<PhoneAuthCredential>()
-    val credential: LiveData<PhoneAuthCredential> = _credential
+    private var _credential = MutableLiveData<AuthCredential>()
+    val credential: LiveData<AuthCredential> = _credential
 
     // 이미 등록된 전화번호 계정이 있는지 여부
     private val _alreadyRegisteredUser = MutableLiveData(false)
@@ -160,10 +160,11 @@ class JoinStep2ViewModel: ViewModel() {
         if(_isCodeSent.value!!){
             try{
                 _errorMessage.value = ""
-                _credential.value = PhoneAuthProvider.getCredential(verificationId.value!!, inputSmsCode.value!!)
+                val phoneCredential = PhoneAuthProvider.getCredential(verificationId.value!!, inputSmsCode.value!!)
 
                 // 로그인 결과를 담아서 이미 등록된 유저인지 확인한다.
-                val signInResult = _auth.signInWithCredential(_credential.value!!).await()
+                val signInResult = _auth.signInWithCredential(phoneCredential).await()
+                _credential.value = signInResult.credential
                 _alreadyRegisteredUser.value = signInResult.additionalUserInfo?.isNewUser != true
                 if(_alreadyRegisteredUser.value == true){
                     _errorMessage.value = "이미 해당 번호로 가입한 계정이 있습니다."
@@ -173,7 +174,6 @@ class JoinStep2ViewModel: ViewModel() {
                         if(provider.providerId != "firebase" && provider.providerId != "phone"){
                             _alreadyRegisteredUserProvider.value = provider.providerId
                             _alreadyRegisteredUserEmail.value = provider.email!!
-                            Log.d("test1234", "${provider.providerId}")
                         }
                     }
                     // 중복인 경우에는 이미 등록된 계정을 지우면 안되기 때문에 로그아웃만 하기
@@ -258,7 +258,7 @@ class JoinStep2ViewModel: ViewModel() {
         _verificationId.value = ""
         _isVerifiedPhone.value = false
         _errorMessage.value = ""
-        _credential = MutableLiveData<PhoneAuthCredential>()
+        _credential = MutableLiveData<AuthCredential>()
         _alreadyRegisteredUser.value = false
         _alreadyRegisteredUserEmail.value = ""
         _alreadyRegisteredUserProvider.value = ""

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
@@ -10,7 +10,6 @@ import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthException
 import com.google.firebase.auth.FirebaseUser
-import com.google.firebase.auth.PhoneAuthCredential
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kr.co.lion.modigm.model.UserData
@@ -67,9 +66,9 @@ class JoinViewModel : ViewModel() {
     // 이미 등록된 전화번호 계정의 프로바이더
     var alreadyRegisteredUserProvider = ""
 
-    private val _phoneCredential: MutableLiveData<PhoneAuthCredential> = MutableLiveData()
+    private val _phoneCredential: MutableLiveData<AuthCredential> = MutableLiveData()
 
-    fun setPhoneCredential(credential: PhoneAuthCredential){
+    fun setPhoneCredential(credential: AuthCredential){
         _phoneCredential.value = credential
     }
 
@@ -156,6 +155,8 @@ class JoinViewModel : ViewModel() {
     suspend fun completeJoinEmailUser(){
         // 메일 계정을 전화번호 계정과 연결
         linkEmailAndPhone()
+        _user.value = _auth.currentUser
+
         // UserInfoData 객체 생성
         val user = createUserInfoData()
         // 파이어스토어에 데이터 저장
@@ -187,9 +188,11 @@ class JoinViewModel : ViewModel() {
         viewModelScope.launch {
             // SNS 계정과 전화번호 계정을 연결
             linkSnsAndPhone()
+            _user.value = _auth.currentUser
 
             // UserInfoData 객체 생성
             val user = createUserInfoData()
+            // 파이어스토어에 데이터 저장
             _userInfoRepository.insetUserData(user)
 
             _joinCompleted.value = true

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
@@ -172,11 +172,12 @@ class JoinViewModel : ViewModel() {
                 // 카카오 등 파이어베이스에서 지원하지 않는 공급자는 customToken으로 로그인
                 signInResult = _auth.signInWithCustomToken(snsCustomToken.value!!).await()
             }
-            "github" -> {
+            "github.com" -> {
                 // 깃허브 등 파이어베이스에서 지원하는 공급자는 credential로 로그인
                 signInResult = _auth.signInWithCredential(snsCredential.value!!).await()
             }
         }
+        _uid.value = signInResult?.user?.uid
         // 로그인 계정과 전화번호 연결
         signInResult?.user?.linkWithCredential(_phoneCredential.value!!)?.await()
     }

--- a/app/src/main/java/kr/co/lion/modigm/util/JoinType.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/JoinType.kt
@@ -12,7 +12,7 @@ enum class JoinType (var provider:String, var icon:Int) {
         fun getType(str:String):JoinType{
             return when(str){
                 "kakao" -> KAKAO
-                "github" -> GITHUB
+                "github.com" -> GITHUB
                 "password" -> EMAIL
                 else -> ERROR
             }

--- a/app/src/main/java/kr/co/lion/modigm/util/JoinType.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/JoinType.kt
@@ -4,8 +4,8 @@ import kr.co.lion.modigm.R
 
 enum class JoinType (var provider:String, var icon:Int) {
     KAKAO("kakao", R.drawable.kakaotalk_sharing_btn_small),
-    GITHUB("github", R.drawable.icon_github_logo),
-    EMAIL("email", R.drawable.email_login_logo),
+    GITHUB("github.com", R.drawable.icon_github_logo),
+    EMAIL("password", R.drawable.email_login_logo),
     ERROR("error", 0);
 
     companion object{
@@ -13,7 +13,7 @@ enum class JoinType (var provider:String, var icon:Int) {
             return when(str){
                 "kakao" -> KAKAO
                 "github" -> GITHUB
-                "email" -> EMAIL
+                "password" -> EMAIL
                 else -> ERROR
             }
         }

--- a/app/src/main/res/layout/fragment_join.xml
+++ b/app/src/main/res/layout/fragment_join.xml
@@ -18,9 +18,10 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <ProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/progressBar_join"
-        style="?android:attr/progressBarStyleHorizontal"
+
+        style="@style/Widget.Material3.LinearProgressIndicator"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:progressTint="@color/pointColor"

--- a/app/src/main/res/layout/fragment_join_step2.xml
+++ b/app/src/main/res/layout/fragment_join_step2.xml
@@ -127,7 +127,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:hint="인증번호 입력"
-                        android:inputType="text"
+                        android:inputType="number"
                         android:text="@={viewModel.inputSmsCode}"
                         android:textSize="16dp" />
                 </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #138 

## 📝작업 내용

> SNS 계정으로 회원가입
> 회원가입 후SharedPreferences에 uid값 저장

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 테스트 번호가 아닌 실제 번호로 테스트할 시 에러가 발생하여 이 부분은 이슈 새로 발행 후 작업이 필요할 것 같습니다.
> 전화번호 중복 확인의 경우 파이어베이스 인증에 한번 로그인을 해줘야 중복확인이 가능한데 이렇게 되면
나중에 이메일(SNS) 계정과 전화번호를 연결할 때 전화 번호 인증 쪽에서 문제가 발생하는 것 같습니다.
전화번호로 계정 중복 여부를 파이어베이스에서 확인하지 않고 DB의 정보로 확인하는 걸로 절차를 바꿔야할 것 같은데
그렇게 된다면 user model에 어느 계정으로 가입했는지 확인하는 'provider' 추가가 필요할 것 같습니다.
