### PR TITLE
[#157] feature 회원가입 기능 디버깅

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -389,9 +389,6 @@ class JoinFragment : Fragment() {
         viewModel.joinCompleted.observe(viewLifecycleOwner){
             hideLoading()
 
-            // SharedPreferences에 uid값 저장
-            viewModel.user.value?.let { it1 -> prefs.setString("uid", it1.uid) }
-
             if(it){
                 parentFragmentManager.beginTransaction()
                     .replace(R.id.containerMain, BottomNaviFragment())

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -1,7 +1,6 @@
 package kr.co.lion.modigm.ui.join
 
 import android.content.Context
-import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.util.TypedValue
@@ -47,18 +46,6 @@ class JoinFragment : Fragment() {
         JoinType.getType(arguments?.getString("joinType")?:"")
     }
 
-    private val customToken: String? by lazy {
-        arguments?.getString("customToken")
-    }
-
-    private val credential: AuthCredential? by lazy {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            arguments?.getParcelable("credential", AuthCredential::class.java)
-        } else {
-            arguments?.getParcelable("credential")
-        }
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -76,17 +63,15 @@ class JoinFragment : Fragment() {
 
     // 번들로 전달받은 값들을 뷰모델 라이브 데이터에 셋팅
     private fun settingValuesFromBundle(){
-        if(customToken != null){
-            viewModel.setSnsCustomToken(customToken?:"")
-        }
-        if(credential != null){
-            viewModel.setSnsCredential(credential!!)
-        }
         if(joinType != null){
             // 프로바이더 셋팅
             viewModel.setUserProvider(joinType?.provider?:"")
             // email 셋팅
             viewModel.setUserEmail()
+            // SNS계정인경우 uid 셋팅
+            if(joinType != JoinType.EMAIL){
+                viewModel.setUserUid()
+            }
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -28,7 +28,7 @@ import kr.co.lion.modigm.ui.join.vm.JoinStep1ViewModel
 import kr.co.lion.modigm.ui.join.vm.JoinStep2ViewModel
 import kr.co.lion.modigm.ui.join.vm.JoinStep3ViewModel
 import kr.co.lion.modigm.ui.join.vm.JoinViewModel
-import kr.co.lion.modigm.ui.study.StudyFragment
+import kr.co.lion.modigm.ui.study.BottomNaviFragment
 import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.JoinType
 import kr.co.lion.modigm.util.ModigmApplication.Companion.prefs
@@ -409,7 +409,7 @@ class JoinFragment : Fragment() {
 
             if(it){
                 parentFragmentManager.beginTransaction()
-                    .replace(R.id.containerMain, StudyFragment())
+                    .replace(R.id.containerMain, BottomNaviFragment())
                     .commit()
             }
         }

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -83,15 +83,10 @@ class JoinFragment : Fragment() {
             viewModel.setSnsCredential(credential!!)
         }
         if(joinType != null){
-            when(joinType){
-                JoinType.EMAIL -> viewModel.setUserProvider(JoinType.EMAIL.provider)
-                else -> {
-                    // sns 계정의 프로바이더 셋팅
-                    viewModel.setUserProvider(joinType?.provider?:"")
-                    // sns 계정의 email 셋팅
-                    viewModel.setSnsEmail()
-                }
-            }
+            // 프로바이더 셋팅
+            viewModel.setUserProvider(joinType?.provider?:"")
+            // email 셋팅
+            viewModel.setUserEmail()
         }
     }
 
@@ -150,7 +145,7 @@ class JoinFragment : Fragment() {
 
         dialogView.findViewById<TextView>(R.id.btnYes).text = "네"
         dialogView.findViewById<TextView>(R.id.btnYes).setOnClickListener {
-            parentFragmentManager.popBackStack(FragmentName.JOIN.str, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+            parentFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
             dialog.dismiss()
         }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -253,11 +253,11 @@ class JoinFragment : Fragment() {
         lifecycleScope.launch {
             showLoading()
             // 처음 화면인 경우
-            if(viewModel.verifiedEmail.isEmpty()
+            if(viewModel.verifiedEmail.value.isNullOrEmpty()
                 // 다음 화면으로 넘어갔다가 다시 돌아와서 이메일을 변경한 경우
-                || (viewModelStep1.userEmail.value != viewModel.verifiedEmail && viewModel.verifiedEmail.isNotEmpty())
+                || (viewModelStep1.userEmail.value != viewModel.verifiedEmail.value && !viewModel.verifiedEmail.value.isNullOrEmpty())
                 ){
-                if(viewModelStep1.userEmail.value != viewModel.verifiedEmail && viewModel.verifiedEmail.isNotEmpty()){
+                if(viewModelStep1.userEmail.value != viewModel.verifiedEmail.value && !viewModel.verifiedEmail.value.isNullOrEmpty()){
                     // 다음 화면으로 넘어갔다가 다시 돌아와서 이메일을 변경한 경우에는 기존에 등록한 이메일 계정을 삭제
                     viewModel.deleteCurrentUser()
                 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -382,7 +382,9 @@ class JoinFragment : Fragment() {
 
         // 인증하기를 다시 했을 때 기존의 인증 완료 취소
         viewModelStep2.isVerifiedPhone.observe(viewLifecycleOwner){
-            viewModel.setPhoneVerified(it)
+            if(!it){
+                viewModel.setPhoneVerified(false)
+            }
         }
 
         // 전화번호가 기존에 등록된 번호인 것이 확인되었을 때

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -288,8 +288,11 @@ class JoinFragment : Fragment() {
         lifecycleScope.launch {
             // 뒤로가기로 돌아왔을 때 이미 인증된 상태인 경우에는 바로 다음페이지로 넘어갈 수 있음
             if(viewModel.phoneVerification.value==true){
-                binding.viewPagerJoin.currentItem += 1
-                return@launch
+                // 전화번호를 변경하지 않은 경우에 넘어갈 수 있음
+                if(viewModel.verifiedPhoneNumber.value == viewModelStep2.userPhone.value){
+                    binding.viewPagerJoin.currentItem += 1
+                    return@launch
+                }
             }
             showLoading()
 
@@ -297,14 +300,15 @@ class JoinFragment : Fragment() {
             if(result.isEmpty()){
                 // 인증 번호 확인 성공
                 viewModelStep2.credential.value?.let { viewModel.setPhoneCredential(it) }
-                viewModel.setPhoneVerificated(true)
+                viewModel.setPhoneVerified(true)
+                viewModelStep2.userPhone.value?.let { viewModel.setVerifiedPhoneNumber(it) }
                 viewModelStep2.cancelTimer()
             }else{
                 // 인증 번호 확인 실패
-                viewModel.setPhoneVerificated(false)
+                viewModel.setPhoneVerified(false)
             }
             if(!viewModel.phoneVerification.value!! && result=="이미 해당 번호로 가입한 계정이 있습니다."){
-                viewModel.setAleradyRegisteredUser(
+                viewModel.setAlreadyRegisteredUser(
                     viewModelStep2.alreadyRegisteredUserEmail.value?:"",
                     viewModelStep2.alreadyRegisteredUserProvider.value?:""
                 )
@@ -378,9 +382,7 @@ class JoinFragment : Fragment() {
 
         // 인증하기를 다시 했을 때 기존의 인증 완료 취소
         viewModelStep2.isVerifiedPhone.observe(viewLifecycleOwner){
-            if(!it){
-                viewModel.setPhoneVerificated(false)
-            }
+            viewModel.setPhoneVerified(it)
         }
 
         // 전화번호가 기존에 등록된 번호인 것이 확인되었을 때

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
@@ -167,6 +167,7 @@ class JoinStep2ViewModel: ViewModel() {
             _errorMessage.value = "이미 해당 번호로 가입한 계정이 있습니다."
             _alreadyRegisteredUserProvider.value = checkResult["provider"]
             _alreadyRegisteredUserEmail.value = checkResult["email"]
+            return _errorMessage.value!!
         }
         // 오류 메시지
         if(_isCodeSent.value!!){

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
@@ -188,6 +188,7 @@ class JoinStep2ViewModel: ViewModel() {
     fun sendCode(activity: Activity){
         // 전화 인증 여부를 초기화
         _isVerifiedPhone.value = false
+        _authExpired.value = false
 
         // 전화번호 앞에 "+82 " 국가코드 붙여주기
         val setNumber = userPhone.value?.replaceRange(0,1,"+82 ")

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
@@ -165,7 +165,9 @@ class JoinViewModel : ViewModel() {
             _userInfoRepository.insetUserData(user)
 
             // SharedPreferences에 유저 정보 저장
-            prefs.setUserData("currentUserData", Gson().toJson(user))
+            prefs.setUserData("currentUserData", user)
+            // SharedPreferences에 uid값 저장
+            prefs.setString("uid", user.userUid)
 
             _joinCompleted.value = true
         }
@@ -182,7 +184,9 @@ class JoinViewModel : ViewModel() {
             _userInfoRepository.insetUserData(user)
 
             // SharedPreferences에 유저 정보 저장
-            prefs.setUserData("currentUserData", Gson().toJson(user))
+            prefs.setUserData("currentUserData", user)
+            // SharedPreferences에 uid값 저장
+            prefs.setString("uid", user.userUid)
 
             _joinCompleted.value = true
         }

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
@@ -63,13 +63,19 @@ class JoinViewModel : ViewModel() {
     // 전화번호 인증
     private var _phoneVerification: MutableLiveData<Boolean> = MutableLiveData()
     val phoneVerification: LiveData<Boolean> = _phoneVerification
+    fun setPhoneVerified(verified:Boolean){
+        _phoneVerification.value = verified
+    }
+
+    // 인증된 전화번호
+    private var _verifiedPhoneNumber: MutableLiveData<String> = MutableLiveData()
+    val verifiedPhoneNumber: LiveData<String> = _verifiedPhoneNumber
+    fun setVerifiedPhoneNumber(phone:String){
+        _verifiedPhoneNumber.value = phone
+    }
 
     // 이미 전화번호가 등록되었는지 여부
     var isPhoneAlreadyRegistered = MutableLiveData(false)
-
-    fun setPhoneVerificated(verificated:Boolean){
-        _phoneVerification.value = verificated
-    }
 
     // 이미 등록된 전화번호 계정의 이메일
     private var _alreadyRegisteredUserEmail: MutableLiveData<String> = MutableLiveData()
@@ -78,7 +84,7 @@ class JoinViewModel : ViewModel() {
     private var _alreadyRegisteredUserProvider: MutableLiveData<String> = MutableLiveData()
     val alreadyRegisteredUserProvider: LiveData<String> = _alreadyRegisteredUserProvider
 
-    fun setAleradyRegisteredUser(email:String, provider:String){
+    fun setAlreadyRegisteredUser(email:String, provider:String){
         _alreadyRegisteredUserEmail.value = email
         _alreadyRegisteredUserProvider.value = provider
     }

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
@@ -57,7 +57,8 @@ class JoinViewModel : ViewModel() {
     }
 
     // auth에 등록된 이메일, 뒤로가기로 이메일을 수정한 경우 비교용
-    var verifiedEmail = ""
+    private var _verifiedEmail: MutableLiveData<String> = MutableLiveData()
+    val verifiedEmail: LiveData<String> = _verifiedEmail
 
     // 전화번호 인증
     private var _phoneVerification: MutableLiveData<Boolean> = MutableLiveData()
@@ -121,7 +122,7 @@ class JoinViewModel : ViewModel() {
             val authResult = _auth.createUserWithEmailAndPassword(_email.value?:"", _password.value?:"").await()
             _user.value = authResult.user
             _uid.value = authResult.user?.uid?:""
-            verifiedEmail = _email.value?:""
+            _verifiedEmail.value = _email.value?:""
             //userCredential.user?.delete()
             //_auth.signOut()
         }catch (e:FirebaseAuthException){
@@ -135,7 +136,7 @@ class JoinViewModel : ViewModel() {
     // 회원가입 이탈 시 이미 Auth에 등록되어있는 인증 정보 삭제
     fun deleteCurrentUser(){
         // 이메일 인증 정보 삭제
-        if(verifiedEmail.isNotEmpty()){
+        if(!verifiedEmail.value.isNullOrEmpty()){
             _user.value?.delete()
         }
         // 전화번호 인증 정보는 이미 중복확인을 할 때 삭제해놓기 때문에 필요없음

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
@@ -8,6 +8,7 @@ import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthException
 import com.google.firebase.auth.FirebaseUser
+import com.google.gson.Gson
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kr.co.lion.modigm.model.UserData
@@ -164,7 +165,7 @@ class JoinViewModel : ViewModel() {
             _userInfoRepository.insetUserData(user)
 
             // SharedPreferences에 유저 정보 저장
-            prefs.setUserData("currentUserData", user)
+            prefs.setUserData("currentUserData", Gson().toJson(user))
 
             _joinCompleted.value = true
         }
@@ -181,7 +182,7 @@ class JoinViewModel : ViewModel() {
             _userInfoRepository.insetUserData(user)
 
             // SharedPreferences에 유저 정보 저장
-            prefs.setUserData("currentUserData", user)
+            prefs.setUserData("currentUserData", Gson().toJson(user))
 
             _joinCompleted.value = true
         }

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kr.co.lion.modigm.model.UserData
 import kr.co.lion.modigm.repository.UserInfoRepository
+import kr.co.lion.modigm.util.ModigmApplication.Companion.prefs
 
 class JoinViewModel : ViewModel() {
 
@@ -162,6 +163,9 @@ class JoinViewModel : ViewModel() {
             // 파이어스토어에 데이터 저장
             _userInfoRepository.insetUserData(user)
 
+            // SharedPreferences에 유저 정보 저장
+            prefs.setUserData("currentUserData", user)
+
             _joinCompleted.value = true
         }
     }
@@ -175,6 +179,9 @@ class JoinViewModel : ViewModel() {
             val user = createUserInfoData()
             // 파이어스토어에 데이터 저장
             _userInfoRepository.insetUserData(user)
+
+            // SharedPreferences에 유저 정보 저장
+            prefs.setUserData("currentUserData", user)
 
             _joinCompleted.value = true
         }

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
@@ -1,6 +1,5 @@
 package kr.co.lion.modigm.ui.join.vm
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -34,11 +33,11 @@ class JoinViewModel : ViewModel() {
     }
 
     // sns email
-    private var _snsEmail: MutableLiveData<String> = MutableLiveData()
-    val snsEmail: LiveData<String> = _snsEmail
-    fun setSnsEmail(){
+    private var _userEmail: MutableLiveData<String> = MutableLiveData()
+    val userEmail: LiveData<String> = _userEmail
+    fun setUserEmail(){
         if(_auth.currentUser != null){
-            _snsEmail.value = _auth.currentUser?.email
+            _userEmail.value = _auth.currentUser?.email
         }
     }
 
@@ -157,30 +156,13 @@ class JoinViewModel : ViewModel() {
         user.userUid = _uid.value?:""
 
         user.userProvider = _userProvider.value?:""
-        user.userEmail = _snsEmail.value?:""
+        user.userEmail = _userEmail.value?:""
         // 각 화면에서 응답받은 정보 가져와서 객체 생성 후 return
         return user
     }
 
-    // 회원가입 완료 전에 이메일 계정과 전화번호 계정을 통합
-    private fun linkEmailAndPhone(){
-        _auth.signInWithEmailAndPassword(_email.value?:"", _password.value?:"").addOnCompleteListener { loginTask ->
-            if(loginTask.isSuccessful){
-                _auth.currentUser?.linkWithCredential(_phoneCredential.value!!)?.addOnCompleteListener { linkTask ->
-                    if(!linkTask.isSuccessful){
-                        Log.d("testError", "linkWithCredential : ${linkTask.exception}")
-                    }
-                }
-            }else{
-                Log.d("testError", "signInWithEmailAndPassword : ${loginTask.exception}")
-            }
-        }
-    }
-
     // 이메일 계정 회원 가입 완료
     suspend fun completeJoinEmailUser(){
-        // 메일 계정을 전화번호 계정과 연결
-        linkEmailAndPhone()
         _user.value = _auth.currentUser
 
         // UserInfoData 객체 생성


### PR DESCRIPTION
## #️⃣연관된 이슈

> #157 

## 📝작업 내용

> 전화번호 인증 부분을 수정했습니다.
> 이메일, SNS 계정과 전화번호 계정을 합쳐주는 과정을 수정했습니다.
전화번호 인증 후 관심분야 선택화면으로 넘어가기 전에 계정이 합쳐지며, JoinFragment 이탈 시 Firebase Auth에 등록된 계정이 삭제됩니다.
> 회원 가입 완료 후 StudyFragment가 아니라 BottomNaviFragment로 이동하도록 수정했습니다.
> 회원 가입 완료 후 SharedPreferences에 유저 정보 저장하도록 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
