### PR TITLE
 [Feature #170] 멤버 목록 화면 구현

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
@@ -69,4 +69,12 @@ class StudyRepository {
         }
     }
 
+    suspend fun getStudyUidListByStudyIdx(studyIdx: Int): List<String>? {
+        return remoteStudyDataSource.selectContentData(studyIdx)?.studyUidList
+    }
+
+    suspend fun getUserDetailsByUid(uid: String): UserData? {
+        return remoteStudyDataSource.loadUserDetailsByUid(uid)
+    }
+
 }

--- a/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
@@ -77,4 +77,9 @@ class StudyRepository {
         return remoteStudyDataSource.loadUserDetailsByUid(uid)
     }
 
+    ////////////////////////////////////
+    suspend fun updateStudyUserList(userUid: String, studyIdx: Int): Boolean {
+        return remoteStudyDataSource.updateStudyUserList(userUid, studyIdx)
+    }
+
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailApplyMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailApplyMemberFragment.kt
@@ -14,7 +14,11 @@ import kr.co.lion.modigm.ui.MainActivity
 import kr.co.lion.modigm.ui.detail.adapter.DetailApplyMembersAdapter
 import kr.co.lion.modigm.ui.detail.adapter.DetailJoinMembersAdapter
 
-
+// 오류 방지 나중에 삭제 예정
+data class Member(
+    val name: String,
+    val intro: String
+)
 class DetailApplyMemberFragment : Fragment() {
 
     lateinit var fragmentDetailApplyMemberBinding: FragmentDetailApplyMemberBinding

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -375,13 +375,17 @@ class DetailFragment : Fragment() {
             // 각 메뉴 아이템에 대한 클릭 리스너 설정
             // 멤버목록
             popupView.findViewById<TextView>(R.id.menuItem1).setOnClickListener {
+                val detailMemberFragment = DetailMemberFragment().apply {
+                    arguments = Bundle().apply {
+                        putInt("studyIdx", currentStudyData?.studyIdx?:0)
+                    }
+                }
+
                 // 화면이동 로직 추가
                 parentFragmentManager.beginTransaction()
-                    .replace(R.id.containerMain, DetailMemberFragment())
+                    .replace(R.id.containerMain, detailMemberFragment)
                     .addToBackStack(FragmentName.DETAIL_MEMBER.str)
                     .commit()
-
-                popupWindow.dismiss()
             }
 
             // 글 편집

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -386,6 +386,8 @@ class DetailFragment : Fragment() {
                     .replace(R.id.containerMain, detailMemberFragment)
                     .addToBackStack(FragmentName.DETAIL_MEMBER.str)
                     .commit()
+
+                popupWindow.dismiss()
             }
 
             // 글 편집

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
@@ -11,24 +11,20 @@ import kr.co.lion.modigm.databinding.FragmentDetailJoinMemberBinding
 import kr.co.lion.modigm.ui.MainActivity
 import kr.co.lion.modigm.ui.detail.adapter.DetailJoinMembersAdapter
 
-data class Member(
-    val name: String,
-    val intro: String
-)
-
 class DetailJoinMemberFragment : Fragment() {
 
     lateinit var fragmentDetailJoinMemberBinding: FragmentDetailJoinMemberBinding
 
-    lateinit var mainActivity: MainActivity
+    // 현재 선택된 스터디 idx 번호를 담을 변수(임시)
+    var studyIdx = 0
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         fragmentDetailJoinMemberBinding = FragmentDetailJoinMemberBinding.inflate(layoutInflater)
-        mainActivity = activity as MainActivity
-
+        // 상품 idx
+        studyIdx = arguments?.getInt("studyIdx")!!
 
         return fragmentDetailJoinMemberBinding.root
     }
@@ -43,14 +39,7 @@ class DetailJoinMemberFragment : Fragment() {
     fun setupRecyclerView() {
         val layoutManager = LinearLayoutManager(context)
         fragmentDetailJoinMemberBinding.recyclerviewDetailJoin.layoutManager = layoutManager
-        // 임시 데이터(확인용)
-        val members = listOf(
-            Member("홍길동", "열심히 일하는 개발자입니다."),
-            Member("김철수", "디자인을 사랑하는 크리에이터입니다."),
-            Member("이영희", "프로젝트 매니지먼트가 전문인 매니저입니다.")
-        )
-        fragmentDetailJoinMemberBinding.recyclerviewDetailJoin.adapter = DetailJoinMembersAdapter(members)
-        Log.d("DetailJoinMemberFragment", "Adapter set with ${members.size} members.")
+
     }
 
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
@@ -6,14 +6,18 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import kr.co.lion.modigm.databinding.FragmentDetailJoinMemberBinding
 import kr.co.lion.modigm.ui.MainActivity
 import kr.co.lion.modigm.ui.detail.adapter.DetailJoinMembersAdapter
+import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
 
 class DetailJoinMemberFragment : Fragment() {
 
-    lateinit var fragmentDetailJoinMemberBinding: FragmentDetailJoinMemberBinding
+    lateinit var binding: FragmentDetailJoinMemberBinding
+    private val viewModel: DetailViewModel by activityViewModels()
+    private lateinit var adapter: DetailJoinMembersAdapter
 
     // 현재 선택된 스터디 idx 번호를 담을 변수(임시)
     var studyIdx = 0
@@ -22,11 +26,12 @@ class DetailJoinMemberFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        fragmentDetailJoinMemberBinding = FragmentDetailJoinMemberBinding.inflate(layoutInflater)
+        binding = FragmentDetailJoinMemberBinding.inflate(layoutInflater)
+        adapter = DetailJoinMembersAdapter()  // adapter 초기화
         // 상품 idx
         studyIdx = arguments?.getInt("studyIdx")!!
 
-        return fragmentDetailJoinMemberBinding.root
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -34,12 +39,28 @@ class DetailJoinMemberFragment : Fragment() {
 
         setupRecyclerView()
 
+        viewModel.loadStudyUids(studyIdx)
+
+        viewModel.studyUids.observe(viewLifecycleOwner) { uids ->
+            viewModel.loadUserDetails(uids)
+            uids.forEach { uid ->
+                Log.d("DetailJoinMemberFragment", "User UID: $uid")
+            }
+        }
+
+
+        viewModel.userDetails.observe(viewLifecycleOwner) { userDetails ->
+            userDetails?.let {
+                adapter.submitList(it)
+            }
+        }
+
     }
 
     fun setupRecyclerView() {
-        val layoutManager = LinearLayoutManager(context)
-        fragmentDetailJoinMemberBinding.recyclerviewDetailJoin.layoutManager = layoutManager
-
+        adapter = DetailJoinMembersAdapter()
+        binding.recyclerviewDetailJoin.layoutManager = LinearLayoutManager(context)
+        binding.recyclerviewDetailJoin.adapter = adapter
     }
 
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.firebase.auth.FirebaseAuth
 import kr.co.lion.modigm.databinding.FragmentDetailJoinMemberBinding
 import kr.co.lion.modigm.ui.MainActivity
 import kr.co.lion.modigm.ui.detail.adapter.DetailJoinMembersAdapter
@@ -22,12 +23,19 @@ class DetailJoinMemberFragment : Fragment() {
     // 현재 선택된 스터디 idx 번호를 담을 변수(임시)
     var studyIdx = 0
 
+    private lateinit var auth: FirebaseAuth
+    private lateinit var currentUserId: String
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentDetailJoinMemberBinding.inflate(layoutInflater)
-        adapter = DetailJoinMembersAdapter()  // adapter 초기화
+
+        auth = FirebaseAuth.getInstance()
+        currentUserId = auth.currentUser?.uid ?: ""
+
+        adapter = DetailJoinMembersAdapter(currentUserId)  // adapter 초기화
         // 상품 idx
         studyIdx = arguments?.getInt("studyIdx")!!
 
@@ -58,7 +66,6 @@ class DetailJoinMemberFragment : Fragment() {
     }
 
     fun setupRecyclerView() {
-        adapter = DetailJoinMembersAdapter()
         binding.recyclerviewDetailJoin.layoutManager = LinearLayoutManager(context)
         binding.recyclerviewDetailJoin.adapter = adapter
     }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
@@ -35,9 +35,11 @@ class DetailJoinMemberFragment : Fragment() {
         auth = FirebaseAuth.getInstance()
         currentUserId = auth.currentUser?.uid ?: ""
 
-        adapter = DetailJoinMembersAdapter(currentUserId)  // adapter 초기화
         // 상품 idx
         studyIdx = arguments?.getInt("studyIdx")!!
+
+        adapter = DetailJoinMembersAdapter(viewModel,currentUserId, studyIdx)  // adapter 초기화
+
 
         return binding.root
     }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailMemberFragment.kt
@@ -16,8 +16,8 @@ class DetailMemberFragment : Fragment() {
 
     lateinit var fragmentDetailMemberBinding: FragmentDetailMemberBinding
 
-    lateinit var mainActivity: MainActivity
-
+    // 현재 선택된 스터디 idx 번호를 담을 변수(임시)
+    var studyIdx = 0
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -25,8 +25,8 @@ class DetailMemberFragment : Fragment() {
     ): View? {
         // Inflate the layout for this fragment
         fragmentDetailMemberBinding = FragmentDetailMemberBinding.inflate(layoutInflater)
-        mainActivity = activity as MainActivity
-
+        // 상품 idx
+        studyIdx = arguments?.getInt("studyIdx")!!
 
         return fragmentDetailMemberBinding.root
     }
@@ -40,7 +40,7 @@ class DetailMemberFragment : Fragment() {
     }
 
     fun setupViewPagerAndTabs() {
-        val adapter = DetailViewPagerAdapter(this)
+        val adapter = DetailViewPagerAdapter(this, studyIdx)
         fragmentDetailMemberBinding.viewPagerDetail.adapter = adapter
 
         TabLayoutMediator(fragmentDetailMemberBinding.tabLayoutDetail, fragmentDetailMemberBinding.viewPagerDetail) { tab, position ->

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
@@ -62,6 +62,7 @@ class DetailJoinMembersAdapter(private val viewModel: DetailViewModel,private va
             storageReference.downloadUrl.addOnSuccessListener { uri ->
                 Glide.with(itemView.context)
                     .load(uri)
+                    .error(R.drawable.icon_error_24px) // 로드 실패 시 표시할 이미지
                     .into(binding.imageViewDetailJoinMember) // ImageView에 이미지 로드
             }.addOnFailureListener {
                 // 에러 처리

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
@@ -1,6 +1,7 @@
 package kr.co.lion.modigm.ui.detail.adapter
 
 import android.app.AlertDialog
+import android.graphics.Color
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -19,7 +20,7 @@ import kr.co.lion.modigm.databinding.RowDetailJoinMemberBinding
 import kr.co.lion.modigm.model.UserData
 import kr.co.lion.modigm.ui.detail.Member
 
-class DetailJoinMembersAdapter: ListAdapter<UserData, DetailJoinMembersAdapter.MemberViewHolder>(UserDiffCallback()) {
+class DetailJoinMembersAdapter(private val currentUserId: String) : ListAdapter<UserData, DetailJoinMembersAdapter.MemberViewHolder>(UserDiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MemberViewHolder {
         val binding = RowDetailJoinMemberBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -41,6 +42,20 @@ class DetailJoinMembersAdapter: ListAdapter<UserData, DetailJoinMembersAdapter.M
 
             Log.d("DetailAdapter", "name: ${user.userName}, intro:${user.userIntro}")
 
+            if (user.userUid == currentUserId) {
+                binding.textViewDetailJoinKick.text = "스터디장"
+                binding.textViewDetailJoinKick.setTextColor(Color.BLACK) // 글씨 색상을 검은색으로 설정
+                binding.textViewDetailJoinKick.isClickable = false // 클릭 비활성화
+                binding.textViewDetailJoinKick.setOnClickListener {
+                    // "스터디장"일 때 아무 동작도 하지 않도록 빈 리스너 설정
+                }
+            } else {
+                binding.textViewDetailJoinKick.text = "내보내기"
+                binding.textViewDetailJoinKick.setOnClickListener {
+                    showKickDialog(user) // 강퇴 다이얼로그 표시
+                }
+            }
+
             // Firebase Storage에서 이미지 URL 가져오기
             val storageReference =
                 FirebaseStorage.getInstance().reference.child("userProfile/${user.userProfilePic}")
@@ -50,10 +65,6 @@ class DetailJoinMembersAdapter: ListAdapter<UserData, DetailJoinMembersAdapter.M
                     .into(binding.imageViewDetailJoinMember) // ImageView에 이미지 로드
             }.addOnFailureListener {
                 // 에러 처리
-            }
-
-            binding.textViewDetailJoinKick.setOnClickListener {
-                showKickDialog(user)
             }
         }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
@@ -7,58 +7,74 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.firebase.storage.FirebaseStorage
 import kr.co.lion.modigm.R
+import kr.co.lion.modigm.databinding.CustomDialogBinding
+import kr.co.lion.modigm.databinding.RowDetailJoinMemberBinding
+import kr.co.lion.modigm.model.UserData
 import kr.co.lion.modigm.ui.detail.Member
 
-class DetailJoinMembersAdapter(private val members: List<Member>) :
-    RecyclerView.Adapter<DetailJoinMembersAdapter.MemberViewHolder>() {
+class DetailJoinMembersAdapter: ListAdapter<UserData, DetailJoinMembersAdapter.MemberViewHolder>(UserDiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MemberViewHolder {
-        val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.row_detail_join_member, parent, false)
-        return MemberViewHolder(view)
+        val binding = RowDetailJoinMemberBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return MemberViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: MemberViewHolder, position: Int) {
-        val member = members[position]
-        holder.bind(member)
+        val userData = getItem(position)
+        holder.bind(userData)
     }
 
-    override fun getItemCount() = members.size
+//    override fun getItemCount() = members.size
 
-    inner class MemberViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        private val nameTextView: TextView = itemView.findViewById(R.id.textViewDetailJoinMemberName)
-        private val introTextView: TextView = itemView.findViewById(R.id.textViewDetailJoinMemberIntro)
-        private val kickTextView: TextView = itemView.findViewById(R.id.textViewDetailJoinKick)
+    inner class MemberViewHolder(private val binding: RowDetailJoinMemberBinding) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(member: Member) {
-            nameTextView.text = member.name
-            introTextView.text = member.intro
+        fun bind(user: UserData) {
+            binding.textViewDetailJoinMemberName.text = user.userName
+            binding.textViewDetailJoinMemberIntro.text = user.userIntro
 
-            kickTextView.setOnClickListener {
-                showKickDialog(member)
+            Log.d("DetailAdapter", "name: ${user.userName}, intro:${user.userIntro}")
+
+            // Firebase Storage에서 이미지 URL 가져오기
+            val storageReference =
+                FirebaseStorage.getInstance().reference.child("userProfile/${user.userProfilePic}")
+            storageReference.downloadUrl.addOnSuccessListener { uri ->
+                Glide.with(itemView.context)
+                    .load(uri)
+                    .into(binding.imageViewDetailJoinMember) // ImageView에 이미지 로드
+            }.addOnFailureListener {
+                // 에러 처리
+            }
+
+            binding.textViewDetailJoinKick.setOnClickListener {
+                showKickDialog(user)
             }
         }
 
 
         // custom dialog
-        fun showKickDialog(member: Member) {
-            val dialogView = LayoutInflater.from(itemView.context).inflate(R.layout.custom_dialog, null)
+        fun showKickDialog(member: UserData) {
+//            val dialogView = LayoutInflater.from(itemView.context).inflate(R.layout.custom_dialog, null)
+            val dialogBinding = CustomDialogBinding.inflate(LayoutInflater.from(itemView.context))
             val dialog =MaterialAlertDialogBuilder(itemView.context,R.style.dialogColor)
                 .setTitle("내보내기 확인")
-                .setMessage("정말로 ${member.name}을(를) 내보내시겠습니까?")
-                .setView(dialogView)
+                .setMessage("정말로 ${member.userName}을(를) 내보내시겠습니까?")
+                .setView(dialogBinding.root)
                 .create()
 
-            dialogView.findViewById<TextView>(R.id.btnYes).setOnClickListener {
+            dialogBinding.btnYes.setOnClickListener {
                 // 예 버튼 로직
                 Log.d("Dialog", "확인을 선택했습니다.")
                 dialog.dismiss()
             }
 
-            dialogView.findViewById<TextView>(R.id.btnNo).setOnClickListener {
+            dialogBinding.btnNo.setOnClickListener {
                 // 아니요 버튼 로직
                 Log.d("Dialog", "취소를 선택했습니다.")
                 dialog.dismiss()
@@ -67,4 +83,15 @@ class DetailJoinMembersAdapter(private val members: List<Member>) :
             dialog.show()
         }
     }
-}
+
+        class UserDiffCallback : DiffUtil.ItemCallback<UserData>() {
+            override fun areItemsTheSame(oldItem: UserData, newItem: UserData): Boolean {
+                return oldItem.userUid == newItem.userUid
+            }
+
+            override fun areContentsTheSame(oldItem: UserData, newItem: UserData): Boolean {
+                return oldItem == newItem
+            }
+        }
+
+    }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailViewPagerAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailViewPagerAdapter.kt
@@ -1,18 +1,23 @@
 package kr.co.lion.modigm.ui.detail.adapter
 
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import kr.co.lion.modigm.ui.detail.DetailApplyMemberFragment
 import kr.co.lion.modigm.ui.detail.DetailJoinMemberFragment
 
-class DetailViewPagerAdapter (fragment: Fragment) : FragmentStateAdapter(fragment) {
+class DetailViewPagerAdapter (fragment: Fragment, private val studyIdx: Int) : FragmentStateAdapter(fragment) {
     override fun getItemCount(): Int = 2
 
     override fun createFragment(position: Int): Fragment {
-        return when (position) {
+        val fragment = when (position) {
             0 -> DetailJoinMemberFragment()
             1 -> DetailApplyMemberFragment()
             else -> throw IllegalStateException("Unexpected position $position")
         }
+        fragment.arguments = Bundle().apply {
+            putInt("studyIdx", studyIdx)
+        }
+        return fragment
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
@@ -40,6 +40,12 @@ class DetailViewModel : ViewModel() {
     private val _userImageUri = MutableLiveData<Uri>()
     val userImageUri: LiveData<Uri> = _userImageUri
 
+    private val _studyUids = MutableLiveData<List<String>>()
+    val studyUids: LiveData<List<String>> = _studyUids
+
+    private val _userDetails = MutableLiveData<List<UserData>>()
+    val userDetails: LiveData<List<UserData>> = _userDetails
+
     fun selectContentData(studyIdx: Int) {
         _isLoading.value = true // 작업 시작 시 로딩을 true로 정확히 설정
         viewModelScope.launch {
@@ -132,6 +138,21 @@ class DetailViewModel : ViewModel() {
                 _userImageUri.postValue(it)
             }.onFailure {
                 Log.e("ViewModel", "Failed to load user image: ${it.message}")
+            }
+        }
+    }
+
+    fun loadStudyUids(studyIdx: Int) {
+        viewModelScope.launch {
+            _studyUids.value = studyRepository.getStudyUidListByStudyIdx(studyIdx)
+        }
+    }
+
+    fun loadUserDetails(uids: List<String>) {
+        viewModelScope.launch {
+            _userDetails.value = uids.mapNotNull { uid ->
+                studyRepository.getUserDetailsByUid(uid)
+
             }
         }
     }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
@@ -46,6 +46,9 @@ class DetailViewModel : ViewModel() {
     private val _userDetails = MutableLiveData<List<UserData>>()
     val userDetails: LiveData<List<UserData>> = _userDetails
 
+    private val _removalStatus = MutableLiveData<Result<Boolean>>()
+    val removalStatus: LiveData<Result<Boolean>> = _removalStatus
+
     fun selectContentData(studyIdx: Int) {
         _isLoading.value = true // 작업 시작 시 로딩을 true로 정확히 설정
         viewModelScope.launch {
@@ -157,5 +160,15 @@ class DetailViewModel : ViewModel() {
         }
     }
 
+    fun updateStudyUserList(userUid: String, studyIdx: Int) {
+        viewModelScope.launch {
+            val result = studyRepository.updateStudyUserList(userUid, studyIdx)
+            if (result) {
+                // 성공적으로 처리됐을 때 UI 업데이트
+            } else {
+                // 실패 처리
+            }
+        }
+    }
 
 }

--- a/app/src/main/res/layout/row_detail_join_member.xml
+++ b/app/src/main/res/layout/row_detail_join_member.xml
@@ -12,7 +12,7 @@
         android:layout_width="60dp"
         android:layout_height="60dp"
         android:scaleType="centerCrop"
-        android:src="@drawable/image_loading_gray"/>
+        android:src="@drawable/icon_account_circle"/>
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -49,6 +49,6 @@
         android:textStyle="bold"
         android:layout_marginStart="16dp"
         android:layout_gravity="center"
-        android:text="내보내기"/>
+        android:text=""/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/row_detail_join_member.xml
+++ b/app/src/main/res/layout/row_detail_join_member.xml
@@ -12,7 +12,7 @@
         android:layout_width="60dp"
         android:layout_height="60dp"
         android:scaleType="centerCrop"
-        android:src="@drawable/image_detail_1"/>
+        android:src="@drawable/image_loading_gray"/>
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -27,7 +27,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="16dp"
-            android:text="OOO"/>
+            android:text=""/>
         <TextView
             android:id="@+id/textViewDetailJoinMemberIntro"
             android:layout_width="wrap_content"
@@ -36,7 +36,7 @@
             android:maxLines="1"
             android:ellipsize="end"
             android:textSize="14dp"
-            android:text="소개글소개글소개글소개글소개글소개글소개글소개글소개글"/>
+            android:text=""/>
 
     </LinearLayout>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

>#170

## 📝작업 내용

> 스터디에 참여중인 멤버 데이터 연결

> 스터디장은 내보낼 수 없고 내보내기 text를 스터디장으로 변경

> 내보내기를 누르고 다이얼로그에서 확인을 누르면 참가자 목록에서 삭제

> 기본 이미지 및 error 이미지 설정

### 스크린샷 (선택)
|데이터 연결 | 내보내기 다이얼로그 | 내보내기|
|--|--|--|
<image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/c89b18b9-a965-4497-aa4b-fe3f3d28a09f" width=250 /> | <image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/6f46890d-862e-4dc9-995b-e58f1358b923" width=250 />|<image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/18c790b5-5646-4f38-b82c-5507cde596d5" width=250 />|


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
