### PR TITLE
[Feature #173] 게시글 삭제처리

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDataSource.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDataSource.kt
@@ -302,4 +302,22 @@ class RemoteStudyDataSource {
         }
     }
 
+    // studyIdx를 이용해 해당 스터디의 정보를 가져오고 studyState를 업데이트한다.
+    suspend fun updateStudyStateByStudyIdx(studyIdx: Int, newState: Boolean) {
+        try {
+            val querySnapshot = studyCollection
+                .whereEqualTo("studyIdx", studyIdx)
+                .get()
+                .await()
+
+            if (!querySnapshot.isEmpty) {
+                val document = querySnapshot.documents.first()
+                studyCollection.document(document.id).update("studyState", newState).await()
+            }
+        } catch (e: Exception) {
+            Log.e("RemoteStudyDataSource", "Failed to update study data: ${e.message}", e)
+            throw e
+        }
+    }
+
 }

--- a/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
@@ -69,4 +69,9 @@ class StudyRepository {
         }
     }
 
+    // 특정 studyIdx에 대한 스터디 정보를 가져오고 studyState를 업데이트한다.
+    suspend fun updateStudyStateByStudyIdx(studyIdx: Int, newState: Boolean) {
+        remoteStudyDataSource.updateStudyStateByStudyIdx(studyIdx, newState)
+    }
+
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -441,9 +441,11 @@ class DetailFragment : Fragment() {
             .create()
 
         dialogView.findViewById<TextView>(R.id.btnYes).setOnClickListener {
+            viewModel.updateStudyStateByStudyIdx(studyIdx)
             // 예 버튼 로직
             Log.d("Dialog", "확인을 선택했습니다.")
             dialog.dismiss()
+            parentFragmentManager.popBackStack()
         }
 
         dialogView.findViewById<TextView>(R.id.btnNo).setOnClickListener {

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
@@ -136,5 +136,21 @@ class DetailViewModel : ViewModel() {
         }
     }
 
+    // 특정 studyIdx의 studyState를 업데이트하는 함수
+    fun updateStudyStateByStudyIdx(studyIdx: Int) {
+        viewModelScope.launch {
+            try {
+                val studyData = studyRepository.selectContentData(studyIdx)
+                if (studyData != null) {
+                    studyRepository.updateStudyStateByStudyIdx(studyIdx, false)
+                } else {
+                    Log.e("ViewModel", "No study found with the given index.")
+                }
+            } catch (e: Exception) {
+                Log.e("ViewModel", "Failed to update study state: ${e.message}")
+            }
+        }
+    }
+
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #173

## 📝작업 내용

> 글 상세 화면에서 게시글 삭제 클릭시 게시글 상태를 삭제로 변경

### 스크린샷 (선택)
|글 삭제 버튼 | 글 삭제 다이얼로그 |
|--|--|
<image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/f3672981-50df-4161-8af9-b2d59a02198e" width=250 /> | <image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/21a14933-7a74-4243-a8a4-cf14a7bd2e49" width=250 />|



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 현재 삭제 후 백스택에서 해당 프래그먼트를 제거했더니 메인 스터디 화면에서 화면 갱신이 안됩니다