### PR TITLE
[#176] feature 비밀번호 변경 기능

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ChangePwFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ChangePwFragment.kt
@@ -33,11 +33,24 @@ class ChangePwFragment : Fragment() {
         binding.changePwViewModel = viewModel
         binding.lifecycleOwner = this
 
+        settingToolbar()
         settingTextInputLayoutError()
         settingChangePWButtonDone()
         settingChangePwResultObserver()
 
         return binding.root
+    }
+
+    // 뒤로가기 버튼
+    private fun settingToolbar(){
+        binding.changePWToolbar.apply {
+            title = "설정"
+            setNavigationIcon(R.drawable.arrow_back_24px)
+            setNavigationOnClickListener {
+                parentFragmentManager.popBackStack()
+            }
+        }
+
     }
 
     // 유효성 검사

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ChangePwFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ChangePwFragment.kt
@@ -5,56 +5,36 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.viewModels
 import kr.co.lion.modigm.R
+import kr.co.lion.modigm.databinding.FragmentChangePwBinding
+import kr.co.lion.modigm.ui.profile.vm.ChangePwViewModel
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [ChangePwFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class ChangePwFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
-        }
-    }
+    lateinit var binding: FragmentChangePwBinding
+    private val viewModel: ChangePwViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_change_pw, container, false)
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_change_pw, container, false)
+        binding.changePwViewModel = viewModel
+        binding.lifecycleOwner = this
+
+        settingErrorText()
+
+        return binding.root
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment ChangePwFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            ChangePwFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
-            }
+    private fun settingErrorText(){
+        binding.changePWTextFieldPW.error = viewModel.oldPwError.value
+        binding.changePWTextFieldNewPW.error = viewModel.newPwError.value
+        binding.changePWTextFieldCheck.error = viewModel.newPwCheckError.value
     }
+
+
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ChangePwFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ChangePwFragment.kt
@@ -10,7 +10,9 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.launch
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentChangePwBinding
 import kr.co.lion.modigm.ui.profile.vm.ChangePwViewModel
@@ -55,7 +57,9 @@ class ChangePwFragment : Fragment() {
     private fun settingChangePWButtonDone(){
         binding.changePWButtonDone.setOnClickListener {
             requireActivity().hideSoftInput()
-            viewModel.changePw()
+            lifecycleScope.launch {
+                viewModel.changePw()
+            }
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ChangePwFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ChangePwFragment.kt
@@ -1,40 +1,84 @@
 package kr.co.lion.modigm.ui.profile
 
+import android.content.Context
 import android.os.Bundle
+import android.util.TypedValue
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.launch
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentChangePwBinding
 import kr.co.lion.modigm.ui.profile.vm.ChangePwViewModel
 
 class ChangePwFragment : Fragment() {
 
-    lateinit var binding: FragmentChangePwBinding
-    private val viewModel: ChangePwViewModel by viewModels()
+    // lateinit var binding: FragmentChangePwBinding
+    // private val viewModel: ChangePwViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        // Inflate the layout for this fragment
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_change_pw, container, false)
-        binding.changePwViewModel = viewModel
-        binding.lifecycleOwner = this
+//        // Inflate the layout for this fragment
+//        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_change_pw, container, false)
+//        binding.changePwViewModel = viewModel
+//        binding.lifecycleOwner = this
+//
+//        settingErrorText()
+//        settingChangePWButtonDone()
 
-        settingErrorText()
-
-        return binding.root
+//         return binding.root
+        return null
     }
 
     private fun settingErrorText(){
-        binding.changePWTextFieldPW.error = viewModel.oldPwError.value
-        binding.changePWTextFieldNewPW.error = viewModel.newPwError.value
-        binding.changePWTextFieldCheck.error = viewModel.newPwCheckError.value
+//        binding.changePWTextFieldPW.error = viewModel.oldPwError.value
+//        binding.changePWTextFieldNewPW.error = viewModel.newPwError.value
+//        binding.changePWTextFieldCheck.error = viewModel.newPwCheckError.value
     }
 
+    private fun settingChangePWButtonDone(){
+//        binding.changePWButtonDone.setOnClickListener {
+//            lifecycleScope.launch {
+//                val result = viewModel.changePw()
+//                if(result){
+//                    parentFragmentManager.popBackStack()
+//                }else{
+//                    showSnackBar()
+//                }
+//            }
+//        }
+    }
+
+    private fun showSnackBar() {
+//
+//        val snackbar =
+//            Snackbar.make(binding.root, "비밀번호 변경 실패", Snackbar.LENGTH_SHORT)
+//
+//        // 스낵바의 뷰를 가져옵니다.
+//        val snackbarView = snackbar.view
+//
+//        // 스낵바 텍스트 뷰 찾기
+//        val textView =
+//            snackbarView.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
+//
+//        // 텍스트 크기를 dp 단위로 설정
+//        val textSizeInPx = dpToPx(requireContext(), 16f)
+//        textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeInPx)
+//
+//        snackbar.show()
+    }
+
+    // 스낵바 글시 크기 설정을 위해 dp를 px로 변환
+    private fun dpToPx(context: Context, dp: Float): Float {
+        return dp * context.resources.displayMetrics.density
+    }
 
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ChangePwFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ChangePwFragment.kt
@@ -10,70 +10,82 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.coroutines.launch
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentChangePwBinding
 import kr.co.lion.modigm.ui.profile.vm.ChangePwViewModel
+import kr.co.lion.modigm.ui.profile.vm.ChangePwErrorMessage
+import kr.co.lion.modigm.util.hideSoftInput
 
 class ChangePwFragment : Fragment() {
 
-    // lateinit var binding: FragmentChangePwBinding
-    // private val viewModel: ChangePwViewModel by viewModels()
+     lateinit var binding: FragmentChangePwBinding
+     private val viewModel: ChangePwViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-//        // Inflate the layout for this fragment
-//        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_change_pw, container, false)
-//        binding.changePwViewModel = viewModel
-//        binding.lifecycleOwner = this
-//
-//        settingErrorText()
-//        settingChangePWButtonDone()
+        // Inflate the layout for this fragment
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_change_pw, container, false)
+        binding.changePwViewModel = viewModel
+        binding.lifecycleOwner = this
 
-//         return binding.root
-        return null
+        settingTextInputLayoutError()
+        settingChangePWButtonDone()
+        settingChangePwResultObserver()
+
+        return binding.root
     }
 
-    private fun settingErrorText(){
-//        binding.changePWTextFieldPW.error = viewModel.oldPwError.value
-//        binding.changePWTextFieldNewPW.error = viewModel.newPwError.value
-//        binding.changePWTextFieldCheck.error = viewModel.newPwCheckError.value
+    // 유효성 검사
+    private fun settingTextInputLayoutError(){
+        viewModel.oldPwError.observe(viewLifecycleOwner){
+            binding.changePWTextFieldPW.error = it
+        }
+        viewModel.newPwError.observe(viewLifecycleOwner){
+            binding.changePWTextFieldNewPW.error = it
+        }
+        viewModel.newPwCheckError.observe(viewLifecycleOwner){
+            binding.changePWTextFieldCheck.error = it
+        }
     }
 
+    // 확인 버튼 클릭 이벤트
     private fun settingChangePWButtonDone(){
-//        binding.changePWButtonDone.setOnClickListener {
-//            lifecycleScope.launch {
-//                val result = viewModel.changePw()
-//                if(result){
-//                    parentFragmentManager.popBackStack()
-//                }else{
-//                    showSnackBar()
-//                }
-//            }
-//        }
+        binding.changePWButtonDone.setOnClickListener {
+            requireActivity().hideSoftInput()
+            viewModel.changePw()
+        }
     }
 
-    private fun showSnackBar() {
-//
-//        val snackbar =
-//            Snackbar.make(binding.root, "비밀번호 변경 실패", Snackbar.LENGTH_SHORT)
-//
-//        // 스낵바의 뷰를 가져옵니다.
-//        val snackbarView = snackbar.view
-//
-//        // 스낵바 텍스트 뷰 찾기
-//        val textView =
-//            snackbarView.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
-//
-//        // 텍스트 크기를 dp 단위로 설정
-//        val textSizeInPx = dpToPx(requireContext(), 16f)
-//        textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeInPx)
-//
-//        snackbar.show()
+    // 비밀번호 변경 결과 옵저버
+    private fun settingChangePwResultObserver(){
+        viewModel.changePwResult.observe(viewLifecycleOwner){
+            when(it){
+                ChangePwErrorMessage.CHANGE_PW_SUCCESS -> parentFragmentManager.popBackStack()
+                else -> showSnackBar(it.str)
+            }
+        }
+    }
+
+    private fun showSnackBar(result:String) {
+
+        val snackbar =
+            Snackbar.make(binding.root, result, Snackbar.LENGTH_SHORT)
+
+        // 스낵바의 뷰를 가져옵니다.
+        val snackbarView = snackbar.view
+
+        // 스낵바 텍스트 뷰 찾기
+        val textView =
+            snackbarView.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
+
+        // 텍스트 크기를 dp 단위로 설정
+        val textSizeInPx = dpToPx(requireContext(), 16f)
+        textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeInPx)
+
+        snackbar.show()
     }
 
     // 스낵바 글시 크기 설정을 위해 dp를 px로 변환

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ChangePwFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ChangePwFragment.kt
@@ -56,6 +56,8 @@ class ChangePwFragment : Fragment() {
     // 확인 버튼 클릭 이벤트
     private fun settingChangePWButtonDone(){
         binding.changePWButtonDone.setOnClickListener {
+            // 버튼 클릭 방지
+            it.isClickable = false
             requireActivity().hideSoftInput()
             lifecycleScope.launch {
                 viewModel.changePw()
@@ -70,6 +72,8 @@ class ChangePwFragment : Fragment() {
                 ChangePwErrorMessage.CHANGE_PW_SUCCESS -> parentFragmentManager.popBackStack()
                 else -> showSnackBar(it.str)
             }
+            // 버튼 클릭 방지 해제
+            binding.changePWButtonDone.isClickable = true
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/vm/ChangePwViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/vm/ChangePwViewModel.kt
@@ -1,8 +1,12 @@
 package kr.co.lion.modigm.ui.profile.vm
 
+import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 
 class ChangePwViewModel: ViewModel() {
     // 파이어베이스 인증
@@ -25,4 +29,64 @@ class ChangePwViewModel: ViewModel() {
     // 현재 비밀번호 에러 메시지
     val newPwCheckError = MutableLiveData<String>()
 
+
+    // 비밀번호 유효성 검사
+    private fun checkValidation(): Boolean{
+        oldPwError.value = ""
+        newPwError.value = ""
+        newPwCheckError.value = ""
+
+        var result = false
+
+        if(oldPw.value.isNullOrEmpty()) {
+            oldPwError.value = "현재 비밀번호를 입력해주세요."
+            result = true
+        }
+        if(newPw.value.isNullOrEmpty()) {
+            newPwError.value = "새로운 비밀번호를 입력해주세요."
+            result = true
+        }
+        if(newPwCheck.value.isNullOrEmpty()) {
+            newPwCheckError.value = "새로운 비밀번호 확인을 입력해주세요."
+            result = true
+        }
+        if(newPw.value != newPwCheck.value) {
+            newPwCheckError.value = "새로운 비밀번호가 일치하지 않습니다."
+            result = true
+        }
+
+        return result
+    }
+
+    // 비밀번호 변경
+    suspend fun changePw(): Boolean {
+        var result = false
+
+        // 유효성 검사
+        if(checkValidation()) return false
+
+        viewModelScope.launch {
+            // 다시 로그인을 시도해서 현재 비밀번호가 일치하는지 확인
+            try{
+                _auth.signInWithEmailAndPassword(_user?.email?:"", oldPw.value?:"").await()
+            }catch (e: Exception){
+                oldPwError.value = "현재 비밀번호가 일치하지 않습니다."
+                Log.d("changePw","비밀번호 확인 실패 : ${_auth.currentUser?.email}")
+                result = false
+                return@launch
+            }
+
+            // 새로운 비밀번호로 업데이트
+            try {
+                _user?.updatePassword(newPw.value?:"")?.await()
+                result = true
+            }catch (e: Exception){
+                Log.d("changePw", e.toString())
+                result = false
+                return@launch
+            }
+        }
+
+        return result
+    }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/vm/ChangePwViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/vm/ChangePwViewModel.kt
@@ -1,0 +1,28 @@
+package kr.co.lion.modigm.ui.profile.vm
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.google.firebase.auth.FirebaseAuth
+
+class ChangePwViewModel: ViewModel() {
+    // 파이어베이스 인증
+    private val _auth = FirebaseAuth.getInstance()
+    // 현재 유저
+    private val _user = _auth.currentUser
+
+    // 현재 비밀번호
+    val oldPw = MutableLiveData<String>()
+    // 현재 비밀번호 에러 메시지
+    val oldPwError = MutableLiveData<String>()
+
+    // 새로운 비밀번호
+    val newPw = MutableLiveData<String>()
+    // 현재 비밀번호 에러 메시지
+    val newPwError = MutableLiveData<String>()
+
+    // 새로운 비밀번호 확인
+    val newPwCheck = MutableLiveData<String>()
+    // 현재 비밀번호 에러 메시지
+    val newPwCheckError = MutableLiveData<String>()
+
+}

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/vm/ChangePwViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/vm/ChangePwViewModel.kt
@@ -1,6 +1,5 @@
 package kr.co.lion.modigm.ui.profile.vm
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -92,7 +91,6 @@ class ChangePwViewModel: ViewModel() {
 }
 
 enum class ChangePwErrorMessage(var str:String) {
-    NONE(""),
     VALIDATE_FAIL("입력 내용을 다시 확인해주세요"),
     LOGIN_FAIL("현재 비밀번호가 일치하지 않습니다."),
     CHANGE_PW_FAIL("비밀번호 변경에 실패했습니다. 잠시 후 다시 시도해주세요"),

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/vm/ChangePwViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/vm/ChangePwViewModel.kt
@@ -63,29 +63,27 @@ class ChangePwViewModel: ViewModel() {
     }
 
     // 비밀번호 변경
-    fun changePw() {
-
+    suspend fun changePw() {
         // 유효성 검사
-        if(checkValidation()) _changePwResult.value = ChangePwErrorMessage.VALIDATE_FAIL
+        if(checkValidation()){
+            _changePwResult.value = ChangePwErrorMessage.VALIDATE_FAIL
+            return
+        }
 
-        viewModelScope.launch {
-            // 다시 로그인을 시도해서 현재 비밀번호가 일치하는지 확인
-            try{
-                _auth.signInWithEmailAndPassword(_user?.email?:"", oldPw.value?:"").await()
-            }catch (e: Exception){
-                oldPwError.value = "현재 비밀번호가 일치하지 않습니다."
-                _changePwResult.value = ChangePwErrorMessage.LOGIN_FAIL
-                return@launch
-            }
+        try{
+            _auth.signInWithEmailAndPassword(_user?.email?:"", oldPw.value?:"").await()
+        }catch (e: Exception){
+            oldPwError.value = "현재 비밀번호가 일치하지 않습니다."
+            _changePwResult.value = ChangePwErrorMessage.LOGIN_FAIL
+            return
+        }
 
-            // 새로운 비밀번호로 업데이트
-            try {
-                _user?.updatePassword(newPw.value?:"")?.await()
-                _changePwResult.value = ChangePwErrorMessage.CHANGE_PW_SUCCESS
-            }catch (e: Exception){
-                _changePwResult.value = ChangePwErrorMessage.CHANGE_PW_FAIL
-                return@launch
-            }
+        // 새로운 비밀번호로 업데이트
+        try {
+            _user?.updatePassword(newPw.value?:"")?.await()
+            _changePwResult.value = ChangePwErrorMessage.CHANGE_PW_SUCCESS
+        }catch (e: Exception){
+            _changePwResult.value = ChangePwErrorMessage.CHANGE_PW_FAIL
         }
     }
 }

--- a/app/src/main/res/layout/fragment_change_pw.xml
+++ b/app/src/main/res/layout/fragment_change_pw.xml
@@ -3,11 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <data>
-        <variable
-            name="changePwViewModel"
-            type="kr.co.lion.modigm.ui.profile.vm.ChangePwViewModel" />
-    </data>
+<!--    <data>-->
+<!--        <variable-->
+<!--            name="changePwViewModel"-->
+<!--            type="kr.co.lion.modigm.ui.profile.vm.ChangePwViewModel" />-->
+<!--    </data>-->
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -65,8 +65,8 @@
                     android:layout_height="wrap_content"
                     android:hint="현재 비밀번호 입력"
                     android:inputType="text|textPassword"
-                    android:textSize="16dp"
-                    android:value="@={changePwViewModel.oldPw}" />
+                    android:textSize="16dp" />
+<!--                    android:value="@={changePwViewModel.oldPw}" />-->
             </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
@@ -92,8 +92,9 @@
                     android:layout_height="wrap_content"
                     android:hint="새 비밀번호 입력"
                     android:inputType="text|textPassword"
-                    android:value="@={changePwViewModel.newPw}"
                     android:textSize="16dp" />
+<!--                    android:value="@={changePwViewModel.newPw}"-->
+
             </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
@@ -118,8 +119,9 @@
                     android:layout_height="wrap_content"
                     android:hint="비밀번호 확인"
                     android:inputType="text|textPassword"
-                    android:value="@={changePwViewModel.newPwCheck}"
                     android:textSize="16dp" />
+<!--                    android:value="@={changePwViewModel.newPwCheck}"-->
+
             </com.google.android.material.textfield.TextInputLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/fragment_change_pw.xml
+++ b/app/src/main/res/layout/fragment_change_pw.xml
@@ -3,11 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-<!--    <data>-->
-<!--        <variable-->
-<!--            name="changePwViewModel"-->
-<!--            type="com.techit.android.motionmate.viewmodel.userinfo.ChangePwViewModel" />-->
-<!--    </data>-->
+    <data>
+        <variable
+            name="changePwViewModel"
+            type="kr.co.lion.modigm.ui.profile.vm.ChangePwViewModel" />
+    </data>
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -55,6 +55,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="16dp"
                 app:endIconMode="password_toggle"
+                app:errorEnabled="false"
                 app:hintAnimationEnabled="false"
                 app:hintEnabled="false">
 
@@ -64,7 +65,8 @@
                     android:layout_height="wrap_content"
                     android:hint="현재 비밀번호 입력"
                     android:inputType="text|textPassword"
-                    android:textSize="16dp" />
+                    android:textSize="16dp"
+                    android:value="@={changePwViewModel.oldPw}" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
@@ -90,6 +92,7 @@
                     android:layout_height="wrap_content"
                     android:hint="새 비밀번호 입력"
                     android:inputType="text|textPassword"
+                    android:value="@={changePwViewModel.newPw}"
                     android:textSize="16dp" />
             </com.google.android.material.textfield.TextInputLayout>
 
@@ -115,6 +118,7 @@
                     android:layout_height="wrap_content"
                     android:hint="비밀번호 확인"
                     android:inputType="text|textPassword"
+                    android:value="@={changePwViewModel.newPwCheck}"
                     android:textSize="16dp" />
             </com.google.android.material.textfield.TextInputLayout>
 
@@ -132,7 +136,7 @@
                     android:textSize="14dp"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent" />
+                    app:layout_constraintStart_toStartOf="parent"/>
             </androidx.constraintlayout.widget.ConstraintLayout>
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_change_pw.xml
+++ b/app/src/main/res/layout/fragment_change_pw.xml
@@ -3,11 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-<!--    <data>-->
-<!--        <variable-->
-<!--            name="changePwViewModel"-->
-<!--            type="kr.co.lion.modigm.ui.profile.vm.ChangePwViewModel" />-->
-<!--    </data>-->
+    <data>
+        <variable
+            name="changePwViewModel"
+            type="kr.co.lion.modigm.ui.profile.vm.ChangePwViewModel" />
+    </data>
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -65,8 +65,8 @@
                     android:layout_height="wrap_content"
                     android:hint="현재 비밀번호 입력"
                     android:inputType="text|textPassword"
-                    android:textSize="16dp" />
-<!--                    android:value="@={changePwViewModel.oldPw}" />-->
+                    android:textSize="16dp"
+                    android:text="@={changePwViewModel.oldPw}" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
@@ -92,8 +92,8 @@
                     android:layout_height="wrap_content"
                     android:hint="새 비밀번호 입력"
                     android:inputType="text|textPassword"
-                    android:textSize="16dp" />
-<!--                    android:value="@={changePwViewModel.newPw}"-->
+                    android:textSize="16dp"
+                    android:text="@={changePwViewModel.newPw}" />
 
             </com.google.android.material.textfield.TextInputLayout>
 
@@ -119,8 +119,8 @@
                     android:layout_height="wrap_content"
                     android:hint="비밀번호 확인"
                     android:inputType="text|textPassword"
-                    android:textSize="16dp" />
-<!--                    android:value="@={changePwViewModel.newPwCheck}"-->
+                    android:textSize="16dp"
+                    android:text="@={changePwViewModel.newPwCheck}" />
 
             </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #176 

## 📝작업 내용

> 비밀번호 변경 기능

> 화면과 같이 현재 비밀번호를 확인하고 비밀번호를 변경하는 절차는 파이어베이스 인증에서 제공하지 않습니다.
> 따라서 로그인 절차를 실행(로그인이 실패해도 현재 로그인 상태는 유지됩니다.)하여 현재 비밀번호를 확인하고,
> 그다음에 비밀번호를 업데이트 하는 방식으로 구현했습니다.

### 스크린샷 (선택)
| 현재 비밀번호를 잘못 입력한 경우 | 새 비밀번호와 비밀번호 확인이 <br>일치하지 않는 경우 | 입력값이 비어있을 때 |
| -- | -- | -- |
| <image src="https://github.com/APP-Android2/FinalProject-modigm/assets/121005637/cf781f8a-402f-4e9f-be4e-d4d3be71e79f" width="250" /> | <image src="https://github.com/APP-Android2/FinalProject-modigm/assets/121005637/24b74c87-3c35-4daa-9ab8-05d44edcfaa0" width="250" /> | <image src="https://github.com/APP-Android2/FinalProject-modigm/assets/121005637/3c07fe1b-9f0a-4006-983a-6c93e612d940" width="250" /> |

툴바 아래와 같이 셋팅 했습니다.

![image](https://github.com/APP-Android2/FinalProject-modigm/assets/121005637/e76ae375-055f-4527-b044-eb601fe2fc52)



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
