### PR TITLE
188 feature 좋아요 이미지 데이터 가져오기

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDataSource.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDataSource.kt
@@ -369,29 +369,6 @@ class RemoteStudyDataSource {
         }
     }
 
-    // Firestore에 좋아요 데이터를 업데이트하는 메서드
-    suspend fun updateFirestoreLikeCollection(userUid: String, likeData: Map<String, Any>) {
-        val documentReference = FirebaseFirestore.getInstance().collection("like").document(userUid)
-        val document = documentReference.get().await()
-        if (document.exists()) {
-            documentReference.update("likes", FieldValue.arrayUnion(likeData)).await()
-        } else {
-            documentReference.set(mapOf("likes" to listOf(likeData))).await()
-        }
-    }
-
-    // studyLikeState 업데이트
-    suspend fun updateStudyLikeState(studyIdx: Int, isLiked: Boolean) {
-        val querySnapshot = studyCollection
-            .whereEqualTo("studyIdx", studyIdx)
-            .get()
-            .await()
-
-        querySnapshot.documents.forEach { document ->
-            document.reference.update("studyLikeState", isLiked).await()
-        }
-    }
-
     suspend fun addLike(uid: String, studyIdx: Int) {
         val newLikeIdx = getLikeSequence() + 1  // likeIdx 값 증가
         updateLikeSequence(newLikeIdx)  // 새로운 likeIdx로 업데이트

--- a/app/src/main/java/kr/co/lion/modigm/repository/LikeRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/LikeRepository.kt
@@ -1,7 +1,6 @@
 package kr.co.lion.modigm.repository
 
 import kr.co.lion.modigm.db.like.RemoteLikeDataSource
-import kr.co.lion.modigm.db.study.RemoteStudyDataSource
 import kr.co.lion.modigm.model.StudyData
 
 class LikeRepository {

--- a/app/src/main/java/kr/co/lion/modigm/ui/MainActivity.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/MainActivity.kt
@@ -13,7 +13,7 @@ import kr.co.lion.modigm.ui.study.BottomNaviFragment
 import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.ModigmApplication
 import kr.co.lion.modigm.util.showCustomSnackbar
-import android.util.Log
+//import android.util.Log
 import kr.co.lion.modigm.ui.write.WriteFragment
 
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/like/LikeFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/like/LikeFragment.kt
@@ -63,7 +63,10 @@ class LikeFragment : Fragment() {
 
     fun setupRecyclerView() {
         binding.recyclerviewLike.layoutManager = LinearLayoutManager(context)
-        likeAdapter = LikeAdapter(emptyList())
+//        likeAdapter = LikeAdapter(emptyList())
+        likeAdapter = LikeAdapter(emptyList()) { study ->
+            viewModel.toggleLike(uid, study.studyIdx)
+        }
         binding.recyclerviewLike.adapter = likeAdapter
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/like/LikeFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/like/LikeFragment.kt
@@ -63,7 +63,6 @@ class LikeFragment : Fragment() {
 
     fun setupRecyclerView() {
         binding.recyclerviewLike.layoutManager = LinearLayoutManager(context)
-//        likeAdapter = LikeAdapter(emptyList())
         likeAdapter = LikeAdapter(emptyList()) { study ->
             viewModel.toggleLike(uid, study.studyIdx)
         }

--- a/app/src/main/java/kr/co/lion/modigm/ui/like/adapter/LikeAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/like/adapter/LikeAdapter.kt
@@ -33,8 +33,6 @@ class LikeAdapter(private var studyList: List<StudyData>, private val onLikeClic
         fun bind(study: StudyData) {
             binding.apply {
 
-//                imageViewLikeCover.setImageResource(R.drawable.image_detail_1)
-
                 // Firebase Storage에서 이미지 URL 가져오기
                 val storageReference =
                     FirebaseStorage.getInstance().reference.child("studyPic/${study.studyPic}")

--- a/app/src/main/java/kr/co/lion/modigm/ui/like/adapter/LikeAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/like/adapter/LikeAdapter.kt
@@ -5,6 +5,8 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.google.firebase.storage.FirebaseStorage
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.RowLikeBinding
 import kr.co.lion.modigm.model.StudyData
@@ -31,7 +33,19 @@ class LikeAdapter(private var studyList: List<StudyData>) : RecyclerView.Adapter
         fun bind(study: StudyData) {
             binding.apply {
 
-                imageViewLikeCover.setImageResource(R.drawable.image_detail_1)
+//                imageViewLikeCover.setImageResource(R.drawable.image_detail_1)
+
+                // Firebase Storage에서 이미지 URL 가져오기
+                val storageReference =
+                    FirebaseStorage.getInstance().reference.child("studyPic/${study.studyPic}")
+                storageReference.downloadUrl.addOnSuccessListener { uri ->
+                    Glide.with(itemView.context)
+                        .load(uri)
+                        .error(R.drawable.icon_error_24px) // 로드 실패 시 표시할 이미지
+                        .into(imageViewLikeCover) // ImageView에 이미지 로드
+                }.addOnFailureListener {
+                    // 에러 처리
+                }
 
                 // 모집 상태에 따라 텍스트와 색상 설정
                 textViewLikeState.text = if (study.studyState) "모집 중" else "모집 마감"

--- a/app/src/main/java/kr/co/lion/modigm/ui/like/adapter/LikeAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/like/adapter/LikeAdapter.kt
@@ -11,7 +11,7 @@ import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.RowLikeBinding
 import kr.co.lion.modigm.model.StudyData
 
-class LikeAdapter(private var studyList: List<StudyData>) : RecyclerView.Adapter<LikeAdapter.StudyViewHolder>() {
+class LikeAdapter(private var studyList: List<StudyData>, private val onLikeClick: (StudyData) -> Unit) : RecyclerView.Adapter<LikeAdapter.StudyViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StudyViewHolder {
         val binding = RowLikeBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -104,6 +104,20 @@ class LikeAdapter(private var studyList: List<StudyData>) : RecyclerView.Adapter
                     0 -> "신청제"
                     1 -> "선착순"
                     else -> "기타"
+                }
+
+                // 좋아요 상태에 따라 하트 아이콘 및 색상 변경
+                if (study.studyLikeState) {
+                    imageViewLikeHeart.setImageResource(R.drawable.icon_favorite_full_24px)
+                    imageViewLikeHeart.setColorFilter(Color.parseColor("#D73333"))
+                } else {
+                    imageViewLikeHeart.setImageResource(R.drawable.icon_favorite_24px)
+                    imageViewLikeHeart.setColorFilter(ContextCompat.getColor(itemView.context, R.color.pointColor))
+                }
+
+                // 좋아요 아이콘 클릭 이벤트 처리
+                imageViewLikeHeart.setOnClickListener {
+                    onLikeClick(study)
                 }
             }
         }

--- a/app/src/main/java/kr/co/lion/modigm/ui/like/vm/LikeViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/like/vm/LikeViewModel.kt
@@ -5,12 +5,16 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import kr.co.lion.modigm.model.StudyData
 import kr.co.lion.modigm.repository.LikeRepository
+import kr.co.lion.modigm.repository.StudyRepository
 
 class LikeViewModel : ViewModel() {
     private val likeRepository = LikeRepository()
+    private val studyRepository = StudyRepository()
 
     private val _likedStudies = MutableLiveData<List<StudyData>>()
     val likedStudies: LiveData<List<StudyData>> = _likedStudies
@@ -25,6 +29,37 @@ class LikeViewModel : ViewModel() {
             } catch (e: Exception) {
                 Log.e("LikeViewModel", "Error loading liked studies", e)
                 _likedStudies.postValue(emptyList())
+            }
+        }
+    }
+
+    fun toggleLike(uid: String, studyIdx: Int) {
+        viewModelScope.launch {
+            try {
+                val studyCollection = FirebaseFirestore.getInstance().collection("Study")
+                val query = studyCollection.whereEqualTo("studyIdx", studyIdx)
+                val querySnapshot = query.get().await()
+
+                if (!querySnapshot.isEmpty) {
+                    val document = querySnapshot.documents[0]
+                    val currentlyLiked = document.getBoolean("studyLikeState") ?: false
+                    val newLikeState = !currentlyLiked
+
+                    document.reference.update("studyLikeState", newLikeState).await()
+
+                    if (newLikeState) {
+                        studyRepository.addLike(uid, studyIdx)
+                    } else {
+                        studyRepository.removeLike(uid, studyIdx)
+                    }
+
+                    // 좋아요 상태 업데이트 후 목록 새로고침
+                    loadLikedStudies(uid)
+                } else {
+                    Log.e("LikeViewModel", "No matching document found for studyIdx: $studyIdx")
+                }
+            } catch (e: Exception) {
+                Log.e("LikeViewModel", "Error toggling like", e)
             }
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #188

## 📝작업 내용

> 저번 pr내용까지 여기다가 다 적어 두겠습니다!

> 글 상세 페이지에서 하단 하트아이콘 클릭시 파이어베이스 서버에 데이터 저장

> 스터디 좋아요 상태가 true일 경우 하트 아이콘이 눌린 상태 유지

> 하트를 다시 눌러 취소 할경우 서버에서 데이터 삭제

> 좋아요 화면도 동일하게 스터디 좋아요 상태 반영 및 좋아요 취소 가능

### 스크린샷 (선택)
|글 상세 좋아요 | 좋아요 화면 |
|--|--|
<image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/60ebb15b-07d9-4bd1-80da-54ec30aa4cf9" width=250 /> | <image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/a6dc7b17-d51f-4040-a27a-f77a1f9646ff" width=250 />|


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
