### PR TITLE
[Feature] 스터디 신청하기 구현

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDataSource.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDataSource.kt
@@ -507,4 +507,38 @@ class RemoteStudyDataSource {
             }
     }
 
+    fun removeUserFromStudyApplyList(studyIdx: Int, userUid: String, callback: (Boolean) -> Unit) {
+        studyCollection
+            .whereEqualTo("studyIdx", studyIdx)
+            .get()
+            .addOnSuccessListener { documents ->
+                if (!documents.isEmpty) {
+                    val studyDoc = documents.documents[0]
+                    val studyRef = studyDoc.reference
+                    val applyList = studyDoc.get("studyApplyList") as MutableList<String>
+
+                    if (applyList.contains(userUid)) {
+                        applyList.remove(userUid)
+                        studyRef.update("studyApplyList", applyList)
+                            .addOnSuccessListener {
+                                Log.d("FirestoreDataSource", "User removed from apply list")
+                                callback(true)
+                            }
+                            .addOnFailureListener { e ->
+                                Log.w("FirestoreDataSource", "Error removing user from apply list", e)
+                                callback(false)
+                            }
+                    } else {
+                        callback(false)
+                    }
+                } else {
+                    callback(false)
+                }
+            }
+            .addOnFailureListener { exception ->
+                Log.w("FirestoreDataSource", "Error getting documents: ", exception)
+                callback(false)
+            }
+    }
+
 }

--- a/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDataSource.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDataSource.kt
@@ -3,8 +3,10 @@ package kr.co.lion.modigm.db.study
 import android.content.Context
 import android.net.Uri
 import android.util.Log
+import android.view.View
 import android.widget.ImageView
 import com.bumptech.glide.Glide
+import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FieldValue
@@ -437,6 +439,48 @@ class RemoteStudyDataSource {
         }
     }
 
+    // UID를 스터디의 신청 리스트에 추가
+//    suspend fun addToApplyList(studyIdx: Int, uid: String) {
+//        val studyDocument = studyCollection.whereEqualTo("studyIdx", studyIdx).get().await().documents.firstOrNull()
+//        studyDocument?.reference?.update("studyApplyList", FieldValue.arrayUnion(uid))
+//    }
+//
+//    // UID를 스터디의 참여자 리스트에 추가
+//    suspend fun addToStudyUidList(studyIdx: Int, uid: String) {
+//        val studyDocument = studyCollection.whereEqualTo("studyIdx", studyIdx).get().await().documents.firstOrNull()
+//        studyDocument?.reference?.update("studyUidList", FieldValue.arrayUnion(uid))
+//    }
 
+    suspend fun addToApplyList(studyIdx: Int, uid: String) {
+        try {
+            Log.d("StudyDataSource", "Fetching document with studyIdx: $studyIdx")
+            val studyDocument = studyCollection.whereEqualTo("studyIdx", studyIdx).get().await().documents.firstOrNull()
+            if (studyDocument != null) {
+                Log.d("StudyDataSource", "Document found, updating apply list")
+                studyDocument.reference.update("studyApplyList", FieldValue.arrayUnion(uid))
+                Log.d("StudyDataSource", "Apply list updated with UID: $uid")
+            } else {
+                Log.e("StudyDataSource", "No document found for studyIdx: $studyIdx")
+            }
+        } catch (e: Exception) {
+            Log.e("StudyDataSource", "Error in addToApplyList: ${e.message}")
+        }
+    }
+
+    suspend fun addToStudyUidList(studyIdx: Int, uid: String) {
+        try {
+            Log.d("StudyDataSource", "Fetching document with studyIdx: $studyIdx")
+            val studyDocument = studyCollection.whereEqualTo("studyIdx", studyIdx).get().await().documents.firstOrNull()
+            if (studyDocument != null) {
+                Log.d("StudyDataSource", "Document found, updating study UID list")
+                studyDocument.reference.update("studyUidList", FieldValue.arrayUnion(uid))
+                Log.d("StudyDataSource", "Study UID list updated with UID: $uid")
+            } else {
+                Log.e("StudyDataSource", "No document found for studyIdx: $studyIdx")
+            }
+        } catch (e: Exception) {
+            Log.e("StudyDataSource", "Error in addToStudyUidList: ${e.message}")
+        }
+    }
 
 }

--- a/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDataSource.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDataSource.kt
@@ -3,22 +3,17 @@ package kr.co.lion.modigm.db.study
 import android.content.Context
 import android.net.Uri
 import android.util.Log
-import android.view.View
 import android.widget.ImageView
 import com.bumptech.glide.Glide
-import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.Firebase
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.firestore
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.storage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
-import kotlinx.coroutines.withContext
 import kr.co.lion.modigm.model.StudyData
 import kr.co.lion.modigm.model.UserData
 import kotlin.coroutines.resume
@@ -368,29 +363,6 @@ class RemoteStudyDataSource {
             documentReference.update("value", newLikeIdx.toLong()).await()
         } catch (e: Exception) {
             Log.e("Firestore Error", "Error updating likeSequence: ${e.message}")
-        }
-    }
-
-    // Firestore에 좋아요 데이터를 업데이트하는 메서드
-    suspend fun updateFirestoreLikeCollection(userUid: String, likeData: Map<String, Any>) {
-        val documentReference = FirebaseFirestore.getInstance().collection("like").document(userUid)
-        val document = documentReference.get().await()
-        if (document.exists()) {
-            documentReference.update("likes", FieldValue.arrayUnion(likeData)).await()
-        } else {
-            documentReference.set(mapOf("likes" to listOf(likeData))).await()
-        }
-    }
-
-    // studyLikeState 업데이트
-    suspend fun updateStudyLikeState(studyIdx: Int, isLiked: Boolean) {
-        val querySnapshot = studyCollection
-            .whereEqualTo("studyIdx", studyIdx)
-            .get()
-            .await()
-
-        querySnapshot.documents.forEach { document ->
-            document.reference.update("studyLikeState", isLiked).await()
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDataSource.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDataSource.kt
@@ -541,4 +541,38 @@ class RemoteStudyDataSource {
             }
     }
 
+    fun addUserToStudyUidList(studyIdx: Int, userUid: String, callback: (Boolean) -> Unit) {
+        studyCollection
+            .whereEqualTo("studyIdx", studyIdx)
+            .get()
+            .addOnSuccessListener { documents ->
+                if (!documents.isEmpty) {
+                    val studyDoc = documents.documents[0]
+                    val studyRef = studyDoc.reference
+                    val uidList = studyDoc.get("studyUidList") as MutableList<String>
+
+                    if (!uidList.contains(userUid)) {
+                        uidList.add(userUid)
+                        studyRef.update("studyUidList", uidList)
+                            .addOnSuccessListener {
+                                Log.d("FirestoreDataSource", "User added to studyUidList")
+                                callback(true)
+                            }
+                            .addOnFailureListener { e ->
+                                Log.w("FirestoreDataSource", "Error adding user to studyUidList", e)
+                                callback(false)
+                            }
+                    } else {
+                        callback(true)
+                    }
+                } else {
+                    callback(false)
+                }
+            }
+            .addOnFailureListener { exception ->
+                Log.w("FirestoreDataSource", "Error getting documents: ", exception)
+                callback(false)
+            }
+    }
+
 }

--- a/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
@@ -120,4 +120,8 @@ class StudyRepository {
             }
         }
     }
+
+    fun removeUserFromStudyApplyList(studyIdx: Int, userUid: String, callback: (Boolean) -> Unit) {
+        remoteStudyDataSource.removeUserFromStudyApplyList(studyIdx, userUid, callback)
+    }
 }

--- a/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
@@ -2,6 +2,7 @@ package kr.co.lion.modigm.repository
 
 import android.content.Context
 import android.net.Uri
+import android.view.View
 import android.widget.ImageView
 import kr.co.lion.modigm.db.study.RemoteStudyDataSource
 import kr.co.lion.modigm.model.StudyData
@@ -98,4 +99,13 @@ class StudyRepository {
 
     // 스터디 정보 업로드
     suspend fun uploadStudyData(studyData: StudyData) = remoteStudyDataSource.uploadStudyData(studyData)
+
+
+    suspend fun applyToStudy(studyIdx: Int, uid: String) {
+        remoteStudyDataSource.addToApplyList(studyIdx, uid)
+    }
+
+    suspend fun joinStudy(studyIdx: Int, uid: String) {
+        remoteStudyDataSource.addToStudyUidList(studyIdx, uid)
+    }
 }

--- a/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
@@ -108,4 +108,16 @@ class StudyRepository {
     suspend fun joinStudy(studyIdx: Int, uid: String) {
         remoteStudyDataSource.addToStudyUidList(studyIdx, uid)
     }
+
+    fun fetchStudyApplyMembers(studyIdx: Int, callback: (List<UserData>) -> Unit) {
+        remoteStudyDataSource.getStudyApplyList(studyIdx) { userIds ->
+            if (userIds.isNotEmpty()) {
+                remoteStudyDataSource.getUsersByIds(userIds) { users ->
+                    callback(users)
+                }
+            } else {
+                callback(emptyList())
+            }
+        }
+    }
 }

--- a/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/StudyRepository.kt
@@ -124,4 +124,8 @@ class StudyRepository {
     fun removeUserFromStudyApplyList(studyIdx: Int, userUid: String, callback: (Boolean) -> Unit) {
         remoteStudyDataSource.removeUserFromStudyApplyList(studyIdx, userUid, callback)
     }
+
+    fun addUserToStudyUidList(studyIdx: Int, userUid: String, callback: (Boolean) -> Unit) {
+        remoteStudyDataSource.addUserToStudyUidList(studyIdx, userUid, callback)
+    }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailApplyMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailApplyMemberFragment.kt
@@ -53,11 +53,17 @@ class DetailApplyMemberFragment : Fragment() {
 
         viewModel.applyMembers.observe(viewLifecycleOwner) { members ->
             Log.d("DetailApplyMemberFragment", "Observed members: $members")
-            adapter.submitList(members)
+            if (members.isEmpty()) {
+                binding.recyclerviewDetailApply.visibility = View.GONE
+                binding.blankLayoutDetail.visibility = View.VISIBLE
+            } else {
+                binding.recyclerviewDetailApply.visibility = View.VISIBLE
+                binding.blankLayoutDetail.visibility = View.GONE
+                adapter.submitList(members)
+            }
         }
 
         viewModel.loadApplyMembers(studyIdx)
-
 
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailApplyMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailApplyMemberFragment.kt
@@ -6,34 +6,44 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.firebase.auth.FirebaseAuth
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentDetailApplyMemberBinding
 import kr.co.lion.modigm.databinding.FragmentDetailMemberBinding
 import kr.co.lion.modigm.ui.MainActivity
 import kr.co.lion.modigm.ui.detail.adapter.DetailApplyMembersAdapter
 import kr.co.lion.modigm.ui.detail.adapter.DetailJoinMembersAdapter
+import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
 
-// 오류 방지 나중에 삭제 예정
-data class Member(
-    val name: String,
-    val intro: String
-)
 class DetailApplyMemberFragment : Fragment() {
 
-    lateinit var fragmentDetailApplyMemberBinding: FragmentDetailApplyMemberBinding
+    lateinit var binding: FragmentDetailApplyMemberBinding
+    private val viewModel: DetailViewModel by activityViewModels()
+    private lateinit var adapter: DetailApplyMembersAdapter
 
-    lateinit var mainActivity: MainActivity
+    private lateinit var auth: FirebaseAuth
+    private lateinit var currentUserId: String
+
+    // 현재 선택된 스터디 idx 번호를 담을 변수(임시)
+    var studyIdx = 0
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        fragmentDetailApplyMemberBinding = FragmentDetailApplyMemberBinding.inflate(layoutInflater)
-        mainActivity = activity as MainActivity
+        binding = FragmentDetailApplyMemberBinding.inflate(layoutInflater)
 
+        auth = FirebaseAuth.getInstance()
+        currentUserId = auth.currentUser?.uid ?: ""
 
-        return fragmentDetailApplyMemberBinding.root
+        // 상품 idx
+        studyIdx = arguments?.getInt("studyIdx")!!
+
+        adapter = DetailApplyMembersAdapter(viewModel,currentUserId,studyIdx)
+
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -41,34 +51,18 @@ class DetailApplyMemberFragment : Fragment() {
 
         setupRecyclerView()
 
+        viewModel.applyMembers.observe(viewLifecycleOwner) { members ->
+            Log.d("DetailApplyMemberFragment", "Observed members: $members")
+            adapter.submitList(members)
+        }
+
+        viewModel.loadApplyMembers(studyIdx)
+
+
     }
 
     fun setupRecyclerView() {
-        val layoutManager = LinearLayoutManager(context)
-        fragmentDetailApplyMemberBinding.recyclerviewDetailApply.layoutManager = layoutManager
-
-        // 임시 데이터(데이터 있음 확인용)
-        val members = listOf(
-            Member("홍길동", "열심히 일하는 개발자입니다."),
-            Member("김철수", "디자인을 사랑하는 크리에이터입니다."),
-            Member("이영희", "프로젝트 매니지먼트가 전문인 매니저입니다.")
-        )
-
-        // 임시 데이터(데이터 없음 확인용)
-//        val members = listOf<Member>()
-
-        // recyclerview 어댑처 설정
-        fragmentDetailApplyMemberBinding.recyclerviewDetailApply.adapter = DetailApplyMembersAdapter(members)
-
-        // 데이터 유무에 따른 뷰 가시성 조정
-        if (members.isEmpty()) {
-            fragmentDetailApplyMemberBinding.recyclerviewDetailApply.visibility = View.GONE
-            fragmentDetailApplyMemberBinding.blankLayoutDetail.visibility = View.VISIBLE
-        } else {
-            fragmentDetailApplyMemberBinding.recyclerviewDetailApply.visibility = View.VISIBLE
-            fragmentDetailApplyMemberBinding.blankLayoutDetail.visibility = View.GONE
-        }
-
-        Log.d("DetailJoinMemberFragment", "Adapter set with ${members.size} members.")
+        binding.recyclerviewDetailApply.layoutManager = LinearLayoutManager(context)
+        binding.recyclerviewDetailApply.adapter = adapter
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -22,6 +22,7 @@ import com.bumptech.glide.Glide
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.chip.Chip
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.*
@@ -507,6 +508,7 @@ class DetailFragment : Fragment() {
             // 버튼 클릭 이벤트(채팅 방 이동)
             binding.buttonDetailApply.setOnClickListener {
                 Log.d("DetailFragment", "채팅방 이동1")
+
                 moveChatRoom()
             }
 
@@ -526,14 +528,42 @@ class DetailFragment : Fragment() {
                 if (currentStudyData?.studyApplyMethod==1) {
                     binding.buttonDetailApply.setOnClickListener {
                         Log.d("DetailFragment", "신청")
+                        val method = currentStudyData?.studyApplyMethod // 예: 신청방식을 가져오는 방법에 따라 달라질 수 있음
+                        Log.d("DetailFragment", "Button clicked, method: $method")
+
+                        if (method == 1) {  // 신청하기
+                            viewModel.applyToStudy(studyIdx, uid)
+                            view?.let { v ->
+                                Snackbar.make(v, "신청이 완료되었습니다", Snackbar.LENGTH_LONG).show()
+                                Log.d("DetailFragment", "Snackbar shown for apply")
+                            }
+                        } else {  // 참여하기
+
+                            Log.d("DetailFragment", "Changed button text for join study")
+                        }
                     }
                 }else{
+
+
                     // 선착순일 경우
-                    binding.buttonDetailApply.setOnClickListener {
+                    binding.buttonDetailApply.setOnClickListener {view ->
                         Log.d("DetailFragment", "채팅방 이동2")
-                        // 추후에 주석 풀고 써야함
-                        // addUserToChatMemberList()
-                        moveChatRoom()
+                        // 스터디 참여 인원 확인
+                        val currentSize = currentStudyData?.studyUidList?.size ?: 0
+                        val maxSize = currentStudyData?.studyMaxMember ?: 0
+
+                        if(currentSize >= maxSize){
+                            // 스낵바를 통해 메시지 표시
+                            Snackbar.make(view, "스터디 인원이 이미 가득 찼습니다.", Snackbar.LENGTH_LONG).show()
+                            Log.d("DetailFragment", "스터디 인원이 가득 찼으므로 참여할 수 없습니다.")
+                            return@setOnClickListener  // 추가 동작을 중지
+                        }else{
+                            viewModel.joinStudy(studyIdx, uid)
+                            // 추후에 주석 풀고 써야함
+//                        addUserToChatMemberList()
+                            moveChatRoom()
+                        }
+
                     }
                 }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -42,6 +42,7 @@ import kr.co.lion.modigm.model.UserData
 import kr.co.lion.modigm.ui.chat.ChatRoomFragment
 import kr.co.lion.modigm.ui.chat.vm.ChatRoomViewModel
 import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
+import kr.co.lion.modigm.ui.profile.ProfileFragment
 import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.Skill
 
@@ -115,6 +116,7 @@ class DetailFragment : Fragment() {
             }
         }
 
+        userprofile()
         observeViewModel()
     }
 
@@ -173,6 +175,22 @@ class DetailFragment : Fragment() {
                 .into(binding.imageViewDetailUserPic)
         }
 
+    }
+
+    fun userprofile(){
+        binding.imageViewDetailUserPic.setOnClickListener {
+            val profileFragment = ProfileFragment().apply {
+                arguments = Bundle().apply {
+                    putString("uid", currentStudyData?.studyWriteUid)
+                }
+            }
+
+            // 화면이동 로직 추가
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.containerMain, profileFragment)
+                .addToBackStack(FragmentName.DETAIL_MEMBER.str)
+                .commit()
+        }
     }
 
     fun updateUIIfReady() {

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -286,6 +286,13 @@ class DetailFragment : Fragment() {
                 textViewDetailState.text = "모집 마감"
                 setupStatePopup()
             }
+
+            if (data.studyWriteUid == uid) {
+                fab.visibility = View.GONE
+            }
+            else{
+                fab.visibility = View.VISIBLE
+            }
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -1,8 +1,10 @@
 package kr.co.lion.modigm.ui.detail
 
+import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
+import android.util.TypedValue
 import android.view.Gravity
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -534,7 +536,20 @@ class DetailFragment : Fragment() {
                         if (method == 1) {  // 신청하기
                             viewModel.applyToStudy(studyIdx, uid)
                             view?.let { v ->
-                                Snackbar.make(v, "신청이 완료되었습니다", Snackbar.LENGTH_LONG).show()
+//                                Snackbar.make(v, "신청이 완료되었습니다", Snackbar.LENGTH_LONG).show()
+
+                                val message = "신청이 완료되었습니다"
+                                val snackbar = Snackbar.make(v,message, Snackbar.LENGTH_LONG)
+
+                                // 스낵바의 텍스트 뷰 찾기
+                                val textView = snackbar.view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
+
+                                // dpToPx 메서드를 사용하여 dp를 픽셀로 변환
+                                val textSizeInPx = dpToPx(requireContext(), 14f) // 예시: 텍스트 크기 14 dp
+                                textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeInPx)
+
+                                snackbar.show()
+
                                 Log.d("DetailFragment", "Snackbar shown for apply")
                             }
                         } else {  // 참여하기
@@ -554,9 +569,23 @@ class DetailFragment : Fragment() {
 
                         if(currentSize >= maxSize){
                             // 스낵바를 통해 메시지 표시
-                            Snackbar.make(view, "스터디 인원이 이미 가득 찼습니다.", Snackbar.LENGTH_LONG).show()
+                            view?.let { v ->
+                                val message = "스터디 인원이 이미 가득 찼습니다."
+                                val snackbar = Snackbar.make(v,message, Snackbar.LENGTH_LONG)
+
+                                // 스낵바의 텍스트 뷰 찾기
+                                val textView = snackbar.view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
+
+                                // dpToPx 메서드를 사용하여 dp를 픽셀로 변환
+                                val textSizeInPx = dpToPx(requireContext(), 14f) // 예시: 텍스트 크기 14 dp
+                                textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeInPx)
+
+                                snackbar.show()
+
+                            }
                             Log.d("DetailFragment", "스터디 인원이 가득 찼으므로 참여할 수 없습니다.")
                             return@setOnClickListener  // 추가 동작을 중지
+
                         }else{
                             viewModel.joinStudy(studyIdx, uid)
                             // 추후에 주석 풀고 써야함
@@ -577,6 +606,11 @@ class DetailFragment : Fragment() {
             }
         }
     }
+
+    fun dpToPx(context: Context, dp: Float): Float {
+        return dp * context.resources.displayMetrics.density
+    }
+
 
     fun showStatePopup(anchorView: View) {
         val layoutInflater = LayoutInflater.from(requireContext())

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
@@ -65,23 +65,6 @@ class DetailJoinMemberFragment : Fragment() {
 
         viewModel.loadStudyUids(studyIdx)
 
-//        viewModel.loadStudyUids(studyIdx)
-//
-//        viewModel.studyUids.observe(viewLifecycleOwner) { uids ->
-//            viewModel.loadUserDetails(uids)
-//            uids.forEach { uid ->
-//                Log.d("DetailJoinMemberFragment", "User UID: $uid")
-//            }
-//        }
-//
-//
-//        viewModel.userDetails.observe(viewLifecycleOwner) { userDetails ->
-//            userDetails?.let {
-//                adapter.submitList(it)
-//            }
-//        }
-
-
     }
 
     fun setupRecyclerView() {

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
@@ -7,9 +7,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
 import kr.co.lion.modigm.databinding.FragmentDetailJoinMemberBinding
+import kr.co.lion.modigm.db.study.RemoteStudyDataSource
+import kr.co.lion.modigm.repository.StudyRepository
 import kr.co.lion.modigm.ui.MainActivity
 import kr.co.lion.modigm.ui.detail.adapter.DetailJoinMembersAdapter
 import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
@@ -49,15 +53,9 @@ class DetailJoinMemberFragment : Fragment() {
 
         setupRecyclerView()
 
-        viewModel.loadStudyUids(studyIdx)
-
         viewModel.studyUids.observe(viewLifecycleOwner) { uids ->
             viewModel.loadUserDetails(uids)
-            uids.forEach { uid ->
-                Log.d("DetailJoinMemberFragment", "User UID: $uid")
-            }
         }
-
 
         viewModel.userDetails.observe(viewLifecycleOwner) { userDetails ->
             userDetails?.let {
@@ -65,12 +63,30 @@ class DetailJoinMemberFragment : Fragment() {
             }
         }
 
+        viewModel.loadStudyUids(studyIdx)
+
+//        viewModel.loadStudyUids(studyIdx)
+//
+//        viewModel.studyUids.observe(viewLifecycleOwner) { uids ->
+//            viewModel.loadUserDetails(uids)
+//            uids.forEach { uid ->
+//                Log.d("DetailJoinMemberFragment", "User UID: $uid")
+//            }
+//        }
+//
+//
+//        viewModel.userDetails.observe(viewLifecycleOwner) { userDetails ->
+//            userDetails?.let {
+//                adapter.submitList(it)
+//            }
+//        }
+
+
     }
 
     fun setupRecyclerView() {
         binding.recyclerviewDetailJoin.layoutManager = LinearLayoutManager(context)
         binding.recyclerviewDetailJoin.adapter = adapter
     }
-
 
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailMemberFragment.kt
@@ -58,7 +58,7 @@ class DetailMemberFragment : Fragment() {
                 //네비게이션
                 setNavigationIcon(R.drawable.icon_arrow_back_24px)
                 setNavigationOnClickListener {
-                    // mainActivity.removeFragment(FragmentName.DETAIL_MEMBER)
+                    parentFragmentManager.popBackStack()
                 }
             }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/NoMoveBehavior.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/NoMoveBehavior.kt
@@ -1,0 +1,19 @@
+package kr.co.lion.modigm.ui.detail
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+
+class NoMoveBehavior(context: Context, attrs: AttributeSet) : CoordinatorLayout.Behavior<FloatingActionButton>(context, attrs) {
+
+    override fun layoutDependsOn(parent: CoordinatorLayout, child: FloatingActionButton, dependency: View): Boolean {
+        return false
+    }
+
+    override fun onDependentViewChanged(parent: CoordinatorLayout, child: FloatingActionButton, dependency: View): Boolean {
+        // Do nothing to prevent FAB from moving
+        return false
+    }
+}

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
@@ -31,8 +31,6 @@ class DetailApplyMembersAdapter (private val viewModel: DetailViewModel, private
         holder.bind(userData)
     }
 
-//    override fun getItemCount() = members.size
-
     inner class MemberViewHolder(private val binding: RowDetailApplyMemberBinding) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(user: UserData) {

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
@@ -6,48 +6,48 @@ import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
 import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
+import com.google.firebase.storage.FirebaseStorage
 import kr.co.lion.modigm.R
-import kr.co.lion.modigm.ui.detail.Member
+import kr.co.lion.modigm.databinding.RowDetailApplyMemberBinding
+import kr.co.lion.modigm.model.UserData
+import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
 
-class DetailApplyMembersAdapter (private val members: List<Member>) : RecyclerView.Adapter<DetailApplyMembersAdapter.MemberViewHolder>() {
+class DetailApplyMembersAdapter (private val viewModel: DetailViewModel, private val currentUserId: String, private val studyIdx: Int) : ListAdapter<UserData, DetailApplyMembersAdapter.MemberViewHolder>(UserDiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MemberViewHolder {
-        val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.row_detail_apply_member, parent, false)
-        return MemberViewHolder(view)
+        val binding = RowDetailApplyMemberBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return MemberViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: MemberViewHolder, position: Int) {
-        val member = members[position]
-        holder.bind(member)
+        val userData = getItem(position)
+        holder.bind(userData)
     }
 
-    override fun getItemCount() = members.size
+//    override fun getItemCount() = members.size
 
-    inner class MemberViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        private val nameTextView: TextView = itemView.findViewById(R.id.textViewDetailApplyMemberName)
-        private val introTextView: TextView = itemView.findViewById(R.id.textViewDetailApplyMemberIntro)
-        private val refuseButton: Button = itemView.findViewById(R.id.buttonDetailRefuse)
-        private val acceptButton: Button = itemView.findViewById(R.id.buttonDetailAccept)
+    inner class MemberViewHolder(private val binding: RowDetailApplyMemberBinding) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(member: Member) {
-            nameTextView.text = member.name
-            introTextView.text = member.intro
+        fun bind(user: UserData) {
+            binding.textViewDetailApplyMemberName.text = user.userName
+            binding.textViewDetailApplyMemberIntro.text = user.userIntro
 
             // 거절 버튼
-            refuseButton.setOnClickListener {
-                showRefuseDialog(member)
+            binding.buttonDetailRefuse.setOnClickListener {
+                showRefuseDialog(user)
             }
 
             // 승인 버튼
-            acceptButton.setOnClickListener {
+            binding.buttonDetailAccept.setOnClickListener {
 
-                val snackbar = Snackbar.make(itemView, "${member.name}님의 신청이 승인되었습니다", Snackbar.LENGTH_LONG)
+                val snackbar = Snackbar.make(itemView, "${user.userName}님의 신청이 승인되었습니다", Snackbar.LENGTH_LONG)
 
                 // 스낵바의 뷰를 가져옵니다.
                 val snackbarView = snackbar.view
@@ -61,6 +61,19 @@ class DetailApplyMembersAdapter (private val members: List<Member>) : RecyclerVi
 
                 snackbar.show()
             }
+
+            // Firebase Storage에서 이미지 URL 가져오기
+            val storageReference =
+                FirebaseStorage.getInstance().reference.child("userProfile/${user.userProfilePic}")
+            storageReference.downloadUrl.addOnSuccessListener { uri ->
+                Glide.with(itemView.context)
+                    .load(uri)
+                    .error(R.drawable.icon_error_24px) // 로드 실패 시 표시할 이미지
+                    .into(binding.imageViewDetailApplyMember) // ImageView에 이미지 로드
+            }.addOnFailureListener {
+                // 에러 처리
+            }
+
         }
 
         // 스낵바 글시 크기 설정을 위해 dp를 px로 변환
@@ -71,11 +84,11 @@ class DetailApplyMembersAdapter (private val members: List<Member>) : RecyclerVi
 
 
         // custom dialog
-        fun showRefuseDialog(member: Member) {
+        fun showRefuseDialog(user: UserData) {
             val dialogView = LayoutInflater.from(itemView.context).inflate(R.layout.custom_dialog, null)
             val dialog = MaterialAlertDialogBuilder(itemView.context, R.style.dialogColor)
                 .setTitle("거절 확인")
-                .setMessage("정말로 ${member.name}을(를) 거절하시겠습니까?")
+                .setMessage("정말로 ${user.userName}을(를) 거절하시겠습니까?")
                 .setView(dialogView)
                 .create()
 
@@ -92,6 +105,25 @@ class DetailApplyMembersAdapter (private val members: List<Member>) : RecyclerVi
             }
 
             dialog.show()
+        }
+    }
+
+    fun removeItem(position: Int) {
+        // 현재 리스트에서 해당 아이템을 제거
+        val newList = currentList.toMutableList().apply {
+            removeAt(position)
+        }
+        submitList(newList)  // 변경된 리스트를 다시 제출
+        notifyItemRemoved(position)  // 특정 위치의 아이템 제거 알림
+    }
+
+    class UserDiffCallback : DiffUtil.ItemCallback<UserData>() {
+        override fun areItemsTheSame(oldItem: UserData, newItem: UserData): Boolean {
+            return oldItem.userUid == newItem.userUid
+        }
+
+        override fun areContentsTheSame(oldItem: UserData, newItem: UserData): Boolean {
+            return oldItem == newItem
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
@@ -47,19 +47,51 @@ class DetailApplyMembersAdapter (private val viewModel: DetailViewModel, private
             // 승인 버튼
             binding.buttonDetailAccept.setOnClickListener {
 
-                val snackbar = Snackbar.make(itemView, "${user.userName}님의 신청이 승인되었습니다", Snackbar.LENGTH_LONG)
+//                val snackbar = Snackbar.make(itemView, "${user.userName}님의 신청이 승인되었습니다", Snackbar.LENGTH_LONG)
+//
+//                // 스낵바의 뷰를 가져옵니다.
+//                val snackbarView = snackbar.view
+//
+//                // 스낵바 텍스트 뷰 찾기
+//                val textView = snackbarView.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
+//
+//                // 텍스트 크기를 dp 단위로 설정
+//                val textSizeInPx = dpToPx(itemView.context, 16f)
+//                textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeInPx)
+//
+//                snackbar.show()
 
-                // 스낵바의 뷰를 가져옵니다.
-                val snackbarView = snackbar.view
+//                viewModel.addUserToStudyUidList(studyIdx, user.userUid) { success ->
+//                    if (success) {
+//                        val snackbar = Snackbar.make(itemView, "${user.userName}님의 신청이 승인되었습니다", Snackbar.LENGTH_LONG)
+//                        val snackbarView = snackbar.view
+//                        val textView = snackbarView.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
+//                        val textSizeInPx = dpToPx(itemView.context, 16f)
+//                        textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeInPx)
+//                        snackbar.show()
+//                    } else {
+//                        Log.d("Dialog", "Failed to add user to studyUidList")
+//                    }
+//                }
 
-                // 스낵바 텍스트 뷰 찾기
-                val textView = snackbarView.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
+                viewModel.acceptUser(studyIdx, user.userUid) { success ->
+                    if (success) {
+                        val snackbar = Snackbar.make(itemView, "${user.userName}님의 신청이 승인되었습니다", Snackbar.LENGTH_LONG)
+                        val snackbarView = snackbar.view
+                        val textView = snackbarView.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
+                        val textSizeInPx = dpToPx(itemView.context, 16f)
+                        textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeInPx)
+                        snackbar.show()
 
-                // 텍스트 크기를 dp 단위로 설정
-                val textSizeInPx = dpToPx(itemView.context, 16f)
-                textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeInPx)
-
-                snackbar.show()
+                        // 리스트에서 아이템 제거
+                        val position = adapterPosition
+                        if (position != RecyclerView.NO_POSITION) {
+                            removeItem(position)
+                        }
+                    } else {
+                        Log.d("Dialog", "Failed to accept user")
+                    }
+                }
             }
 
             // Firebase Storage에서 이미지 URL 가져오기

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
@@ -47,33 +47,6 @@ class DetailApplyMembersAdapter (private val viewModel: DetailViewModel, private
             // 승인 버튼
             binding.buttonDetailAccept.setOnClickListener {
 
-//                val snackbar = Snackbar.make(itemView, "${user.userName}님의 신청이 승인되었습니다", Snackbar.LENGTH_LONG)
-//
-//                // 스낵바의 뷰를 가져옵니다.
-//                val snackbarView = snackbar.view
-//
-//                // 스낵바 텍스트 뷰 찾기
-//                val textView = snackbarView.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
-//
-//                // 텍스트 크기를 dp 단위로 설정
-//                val textSizeInPx = dpToPx(itemView.context, 16f)
-//                textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeInPx)
-//
-//                snackbar.show()
-
-//                viewModel.addUserToStudyUidList(studyIdx, user.userUid) { success ->
-//                    if (success) {
-//                        val snackbar = Snackbar.make(itemView, "${user.userName}님의 신청이 승인되었습니다", Snackbar.LENGTH_LONG)
-//                        val snackbarView = snackbar.view
-//                        val textView = snackbarView.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
-//                        val textSizeInPx = dpToPx(itemView.context, 16f)
-//                        textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeInPx)
-//                        snackbar.show()
-//                    } else {
-//                        Log.d("Dialog", "Failed to add user to studyUidList")
-//                    }
-//                }
-
                 viewModel.acceptUser(studyIdx, user.userUid) { success ->
                     if (success) {
                         val snackbar = Snackbar.make(itemView, "${user.userName}님의 신청이 승인되었습니다", Snackbar.LENGTH_LONG)
@@ -88,6 +61,7 @@ class DetailApplyMembersAdapter (private val viewModel: DetailViewModel, private
                         if (position != RecyclerView.NO_POSITION) {
                             removeItem(position)
                         }
+
                     } else {
                         Log.d("Dialog", "Failed to accept user")
                     }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
@@ -95,6 +95,17 @@ class DetailApplyMembersAdapter (private val viewModel: DetailViewModel, private
             dialogView.findViewById<TextView>(R.id.btnYes).setOnClickListener {
                 // 예 버튼 로직
                 Log.d("Dialog", "확인을 선택했습니다.")
+                viewModel.removeUserFromApplyList(studyIdx, user.userUid) { success ->
+                    if (success) {
+                        Log.d("Dialog", "User removed from apply list")
+                        val position = adapterPosition
+                        if (position != RecyclerView.NO_POSITION) {
+                            removeItem(position)
+                        }
+                    } else {
+                        Log.d("Dialog", "Failed to remove user from apply list")
+                    }
+                }
                 dialog.dismiss()
             }
 
@@ -115,6 +126,11 @@ class DetailApplyMembersAdapter (private val viewModel: DetailViewModel, private
         }
         submitList(newList)  // 변경된 리스트를 다시 제출
         notifyItemRemoved(position)  // 특정 위치의 아이템 제거 알림
+
+        // If the list is empty after removing the item, update LiveData
+        if (newList.isEmpty()) {
+            viewModel.loadApplyMembers(studyIdx)
+        }
     }
 
     class UserDiffCallback : DiffUtil.ItemCallback<UserData>() {

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
@@ -71,7 +71,6 @@ class DetailJoinMembersAdapter(private val viewModel: DetailViewModel,private va
 
         // custom dialog
         fun showKickDialog(member: UserData, studyIdx: Int) {
-//            val dialogView = LayoutInflater.from(itemView.context).inflate(R.layout.custom_dialog, null)
             val dialogBinding = CustomDialogBinding.inflate(LayoutInflater.from(itemView.context))
             val dialog =MaterialAlertDialogBuilder(itemView.context,R.style.dialogColor)
                 .setTitle("내보내기 확인")

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
@@ -21,7 +21,6 @@ import kr.co.lion.modigm.databinding.CustomDialogBinding
 import kr.co.lion.modigm.databinding.RowDetailJoinMemberBinding
 import kr.co.lion.modigm.model.StudyData
 import kr.co.lion.modigm.model.UserData
-import kr.co.lion.modigm.ui.detail.Member
 import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
 
 class DetailJoinMembersAdapter(private val viewModel: DetailViewModel,private val currentUserId: String, private val studyIdx: Int) : ListAdapter<UserData, DetailJoinMembersAdapter.MemberViewHolder>(UserDiffCallback()) {

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
@@ -273,4 +273,21 @@ class DetailViewModel : ViewModel() {
         studyRepository.removeUserFromStudyApplyList(studyIdx, userUid, callback)
     }
 
+    fun addUserToStudyUidList(studyIdx: Int, userUid: String, callback: (Boolean) -> Unit) {
+        studyRepository.addUserToStudyUidList(studyIdx, userUid) { success ->
+            callback(success)
+        }
+    }
+
+    fun acceptUser(studyIdx: Int, userUid: String, callback: (Boolean) -> Unit) {
+        addUserToStudyUidList(studyIdx, userUid) { addSuccess ->
+            if (addSuccess) {
+                removeUserFromApplyList(studyIdx, userUid) { removeSuccess ->
+                    callback(removeSuccess)
+                }
+            } else {
+                callback(false)
+            }
+        }
+    }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
@@ -269,4 +269,8 @@ class DetailViewModel : ViewModel() {
         }
     }
 
+    fun removeUserFromApplyList(studyIdx: Int, userUid: String, callback: (Boolean) -> Unit) {
+        studyRepository.removeUserFromStudyApplyList(studyIdx, userUid, callback)
+    }
+
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
@@ -270,12 +270,29 @@ class DetailViewModel : ViewModel() {
     }
 
     fun removeUserFromApplyList(studyIdx: Int, userUid: String, callback: (Boolean) -> Unit) {
-        studyRepository.removeUserFromStudyApplyList(studyIdx, userUid, callback)
+        studyRepository.removeUserFromStudyApplyList(studyIdx, userUid) { success ->
+            if (success) {
+                val currentList = _applyMembers.value?.toMutableList() ?: mutableListOf()
+                currentList.removeAll { it.userUid == userUid }
+                _applyMembers.value = currentList
+                callback(true)
+            } else {
+                callback(false)
+            }
+        }
     }
 
     fun addUserToStudyUidList(studyIdx: Int, userUid: String, callback: (Boolean) -> Unit) {
         studyRepository.addUserToStudyUidList(studyIdx, userUid) { success ->
-            callback(success)
+            if (success) {
+                val currentUids = _studyUids.value?.toMutableList() ?: mutableListOf()
+                currentUids.add(userUid)
+                _studyUids.value = currentUids
+                loadUserDetails(currentUids)
+                callback(true)
+            } else {
+                callback(false)
+            }
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
@@ -60,6 +60,9 @@ class DetailViewModel : ViewModel() {
     private val _applyResult = MutableLiveData<Boolean>()
     val applyResult: LiveData<Boolean> = _applyResult
 
+    private val _applyMembers = MutableLiveData<List<UserData>>()
+    val applyMembers: LiveData<List<UserData>> get() = _applyMembers
+
     fun selectContentData(studyIdx: Int) {
         _isLoading.value = true // 작업 시작 시 로딩을 true로 정확히 설정
         viewModelScope.launch {
@@ -255,6 +258,14 @@ class DetailViewModel : ViewModel() {
     fun joinStudy(studyIdx: Int, uid: String) {
         viewModelScope.launch {
             studyRepository.joinStudy(studyIdx, uid)
+        }
+    }
+
+    fun loadApplyMembers(studyIdx: Int) {
+        Log.d("DetailViewModel", "Loading apply members for studyIdx: $studyIdx")
+        studyRepository.fetchStudyApplyMembers(studyIdx) { members ->
+            Log.d("DetailViewModel", "Loaded members: $members")
+            _applyMembers.value = members
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
@@ -2,6 +2,7 @@ package kr.co.lion.modigm.ui.detail.vm
 
 import android.net.Uri
 import android.util.Log
+import android.view.View
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -55,6 +56,9 @@ class DetailViewModel : ViewModel() {
 
     private val _isLiked = MutableLiveData<Boolean>(false)
     val isLiked: LiveData<Boolean> get() = _isLiked
+
+    private val _applyResult = MutableLiveData<Boolean>()
+    val applyResult: LiveData<Boolean> = _applyResult
 
     fun selectContentData(studyIdx: Int) {
         _isLoading.value = true // 작업 시작 시 로딩을 true로 정확히 설정
@@ -238,6 +242,19 @@ class DetailViewModel : ViewModel() {
                 Log.e("ViewModel", "No study found with idx: $studyIdx")
                 _isLiked.postValue(false) // 문서가 없으면 기본값으로 false 설정
             }
+        }
+    }
+
+    fun applyToStudy(studyIdx: Int, uid: String) {
+        viewModelScope.launch {
+            studyRepository.applyToStudy(studyIdx, uid)
+            _applyResult.postValue(true)
+        }
+    }
+
+    fun joinStudy(studyIdx: Int, uid: String) {
+        viewModelScope.launch {
+            studyRepository.joinStudy(studyIdx, uid)
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/like/LikeFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/like/LikeFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -13,8 +14,10 @@ import com.google.firebase.auth.FirebaseAuth
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentLikeBinding
 import kr.co.lion.modigm.model.StudyData
+import kr.co.lion.modigm.ui.detail.DetailFragment
 import kr.co.lion.modigm.ui.like.adapter.LikeAdapter
 import kr.co.lion.modigm.ui.like.vm.LikeViewModel
+import kr.co.lion.modigm.util.FragmentName
 
 class LikeFragment : Fragment() {
 
@@ -55,6 +58,23 @@ class LikeFragment : Fragment() {
 
         // 좋아요한 스터디 데이터를 로드
         viewModel.loadLikedStudies(uid)
+
+        // 옵저버에서 클릭된 항목 처리
+        likeAdapter.setOnItemClickListener { study ->
+            // 클릭된 항목의 studyIdx를 bundle에 담아서 다음 화면으로 전달
+            val detailFragment = DetailFragment().apply {
+                arguments = Bundle().apply {
+                    putInt("studyIdx", study.studyIdx)
+                    Log.d("likefragment","${study.studyIdx}")
+                }
+            }
+
+            requireActivity().supportFragmentManager.commit {
+                replace(R.id.containerMain, detailFragment)
+                addToBackStack(FragmentName.DETAIL.str)
+            }
+        }
+
     }
 
     fun settingToolbar() {

--- a/app/src/main/java/kr/co/lion/modigm/ui/like/adapter/LikeAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/like/adapter/LikeAdapter.kt
@@ -29,7 +29,23 @@ class LikeAdapter(private var studyList: List<StudyData>, private val onLikeClic
         notifyDataSetChanged()
     }
 
+    // 클릭 리스너 선언
+    private var onItemClickListener: ((StudyData) -> Unit)? = null
+    // 클릭 리스너 설정 함수
+    fun setOnItemClickListener(listener: (StudyData) -> Unit) {
+        onItemClickListener = listener
+    }
+
     inner class StudyViewHolder(private val binding: RowLikeBinding) : RecyclerView.ViewHolder(binding.root) {
+        init {
+            itemView.setOnClickListener {
+                val position = adapterPosition
+                if (position != RecyclerView.NO_POSITION) {
+                    val study = studyList[position]
+                    onItemClickListener?.invoke(study) // 클릭된 항목 정보 전달
+                }
+            }
+        }
         fun bind(study: StudyData) {
             binding.apply {
 

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -348,6 +348,7 @@
             android:layout_marginRight="20dp"
             android:layout_marginBottom="80dp"
             android:backgroundTint="@color/pointColor"
+            app:layout_behavior=" "
             app:tint="@color/white"/>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -161,7 +161,7 @@
                                 android:layout_width="match_parent"
                                 android:layout_height="match_parent"
                                 android:layout_marginTop="20dp"
-                                app:chipSpacingHorizontal="8dp"/>
+                                app:chipSpacingHorizontal="8dp" />
 
 
                             <TextView
@@ -258,6 +258,7 @@
                                     android:layout_height="24dp"
                                     android:src="@drawable/icon_location_on_24px"
                                     app:tint="@color/black" />
+
                                 <LinearLayout
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
@@ -347,6 +348,7 @@
             app:layout_anchorGravity="top|end"
             android:layout_marginRight="20dp"
             android:layout_marginBottom="80dp"
+            android:visibility="gone"
             android:backgroundTint="@color/pointColor"
             app:layout_behavior="kr.co.lion.modigm.ui.detail.NoMoveBehavior"
             app:tint="@color/white"/>

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -348,7 +348,7 @@
             android:layout_marginRight="20dp"
             android:layout_marginBottom="80dp"
             android:backgroundTint="@color/pointColor"
-            app:layout_behavior=" "
+            app:layout_behavior="kr.co.lion.modigm.ui.detail.NoMoveBehavior"
             app:tint="@color/white"/>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/layout/row_detail_apply_member.xml
+++ b/app/src/main/res/layout/row_detail_apply_member.xml
@@ -12,7 +12,7 @@
         android:layout_width="60dp"
         android:layout_height="60dp"
         android:scaleType="centerCrop"
-        android:src="@drawable/image_detail_2"/>
+        android:src="@drawable/icon_account_circle"/>
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -26,7 +26,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="16dp"
-            android:text="OOO"/>
+            android:text=""/>
         <TextView
             android:id="@+id/textViewDetailApplyMemberIntro"
             android:layout_width="wrap_content"
@@ -35,7 +35,7 @@
             android:maxLines="1"
             android:ellipsize="end"
             android:textSize="14dp"
-            android:text="소개글소개글소개글소개글소개글소개글소개글소개글소개글"/>
+            android:text=""/>
 
     </LinearLayout>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #196 

## 📝작업 내용

> 스터디 모집 방법이 선착순인 경우 참여하기 버튼을 누르면 바로 studyUidList에 추가 및 채팅방 이동

> 신청제인경우 신청하기 버튼을 누르면 신청이 완료되었습니다 snackBar가 보이고 studyApplyList에 추가

> 신청한사람이 있는 경우 대기중에 표시

> 승인을 누르면  studyUidList에 추가 및 참가중인 사람들에 추가

> 거절을 누르면 studyApplyList에서 삭제

> 멤버목록 화면 뒤로가기 추가

> 좋아요화면에서 글 상세로 이동(저번에 빼먹어서 여기서 추가했습니다)

> 글 상세화면에서 스낵바가 올라오면서 floating버튼이 위로 올라가는 걸 막았습니다

### 스크린샷 (선택)
|대기중 화면 | 승인 | 참여중에 추가|
|--|--|--|
<image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/e602724d-d7e1-4842-af2b-1d6f712bd95b" width=250 /> | <image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/7a5ec71d-3712-47b5-90db-436abb7e41f6" width=250 />| <image src="https://github.com/APP-Android2/FinalProject-modigm/assets/82036757/54dc3903-4ec0-4c05-aad3-d7bc5e4ef3c6" width=250 />|


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

> 원빈님 채팅방에 사용자 추가하는 코드 주석 풀어두면 될까요?

> 현재 글 상세에서 floating버튼을 눌러서 1대1채팅으로 넘어가는 코드가 없습니당

> 내가보는 글에서는 floating버튼을 숨겨야겠죠...?

> 희원님 프로필 화면으로 이동시킬 때 uid값만 넘겨드리면 될까요? 혹시 몰라서 여쭤봅니당 ㅎㅎ 

> 이외에 고칠 부분 편하게 말씀해주세요! 
