### PR TITLE
[#206] Fix  이름 입력 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinStep2Fragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinStep2Fragment.kt
@@ -29,7 +29,6 @@ class JoinStep2Fragment : Fragment() {
         binding.lifecycleOwner = this
 
         settingTextInputLayoutError()
-        settingTextInputUserName()
         settingTextInputUserPhone()
         settingButtonPhoneAuth()
         settingObserver()
@@ -48,13 +47,6 @@ class JoinStep2Fragment : Fragment() {
         joinStep2ViewModel.inputSmsCodeValidation.observe(viewLifecycleOwner){
             binding.textInputLayoutJoinPhoneAuth.error = it
         }
-    }
-
-    private fun settingTextInputUserName(){
-        // 한글만 입력 되도록
-        val filterAlphaNum = joinStep2ViewModel.filterOnlyKorean()
-        // 아래와 같이 EditText에 적용 한다.
-        binding.textinputJoinUserName.setFilters(arrayOf(filterAlphaNum))
     }
 
     private fun settingTextInputUserPhone(){

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
@@ -88,17 +88,6 @@ class JoinStep2ViewModel: ViewModel() {
         return result
     }
 
-    // 이름을 한글만 입력 가능하게
-    fun filterOnlyKorean(): InputFilter {
-        return InputFilter { source, _, _, _, _, _ ->
-            val ps = Pattern.compile("^[ㄱ-ㅣ가-힣]*$")
-            if (!ps.matcher(source).matches()) {
-                return@InputFilter ""
-            }
-            null
-        }
-    }
-
     // ================2. 전화번호 인증 관련==============================================================
 
     private val _auth = FirebaseAuth.getInstance()

--- a/app/src/main/res/layout/fragment_join_step2.xml
+++ b/app/src/main/res/layout/fragment_join_step2.xml
@@ -50,7 +50,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="이름 입력"
-                    android:inputType="text|textEmailAddress"
+                    android:inputType="text"
                     android:text="@={viewModel.userName}"
                     android:textSize="16dp" />
             </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #206 
## 📝작업 내용

> 회원가입 시 이름을 한글만 입력가능하게 설정해놓았는데 이 부분에서 한글 입력이 안되는 버그가 발생하였습니다.
입력 제어 없이 모든 문자를 입력 가능하게 바꾸었습니다.
inputType은 뜬금없이 이메일로 되어있길래 text로 바꾸었습니다.
### 스크린샷 (선택)
[Screen_recording_20240611_105235.webm](https://github.com/APP-Android2/FinalProject-modigm/assets/121005637/0f170f71-4225-4ae6-b9a4-d8ffd6a7f513)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
