### PR TITLE
[#204] feature - 채팅 방 (멤버 등록 및 내보내기) 데이터 업데이트

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailApplyMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailApplyMemberFragment.kt
@@ -13,6 +13,7 @@ import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentDetailApplyMemberBinding
 import kr.co.lion.modigm.databinding.FragmentDetailMemberBinding
 import kr.co.lion.modigm.ui.MainActivity
+import kr.co.lion.modigm.ui.chat.vm.ChatRoomViewModel
 import kr.co.lion.modigm.ui.detail.adapter.DetailApplyMembersAdapter
 import kr.co.lion.modigm.ui.detail.adapter.DetailJoinMembersAdapter
 import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
@@ -21,6 +22,7 @@ class DetailApplyMemberFragment : Fragment() {
 
     lateinit var binding: FragmentDetailApplyMemberBinding
     private val viewModel: DetailViewModel by activityViewModels()
+    private val chatRoomViewModel: ChatRoomViewModel by activityViewModels()
     private lateinit var adapter: DetailApplyMembersAdapter
 
     private lateinit var auth: FirebaseAuth
@@ -41,7 +43,7 @@ class DetailApplyMemberFragment : Fragment() {
         // 상품 idx
         studyIdx = arguments?.getInt("studyIdx")!!
 
-        adapter = DetailApplyMembersAdapter(viewModel,currentUserId,studyIdx)
+        adapter = DetailApplyMembersAdapter(viewModel, chatRoomViewModel, currentUserId, studyIdx)
 
         return binding.root
     }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -613,8 +613,9 @@ class DetailFragment : Fragment() {
 
                         }else{
                             viewModel.joinStudy(studyIdx, uid)
-                            // 추후에 주석 풀고 써야함
-//                        addUserToChatMemberList()
+                            // 멤버 추가
+                            addUserToChatMemberList()
+                            // 채팅방 이동
                             moveChatRoom()
                         }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
@@ -15,6 +15,7 @@ import kr.co.lion.modigm.databinding.FragmentDetailJoinMemberBinding
 import kr.co.lion.modigm.db.study.RemoteStudyDataSource
 import kr.co.lion.modigm.repository.StudyRepository
 import kr.co.lion.modigm.ui.MainActivity
+import kr.co.lion.modigm.ui.chat.vm.ChatRoomViewModel
 import kr.co.lion.modigm.ui.detail.adapter.DetailJoinMembersAdapter
 import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
 
@@ -22,6 +23,7 @@ class DetailJoinMemberFragment : Fragment() {
 
     lateinit var binding: FragmentDetailJoinMemberBinding
     private val viewModel: DetailViewModel by activityViewModels()
+    private val chatRoomViewModel: ChatRoomViewModel by activityViewModels()
     private lateinit var adapter: DetailJoinMembersAdapter
 
     // 현재 선택된 스터디 idx 번호를 담을 변수(임시)
@@ -42,7 +44,7 @@ class DetailJoinMemberFragment : Fragment() {
         // 상품 idx
         studyIdx = arguments?.getInt("studyIdx")!!
 
-        adapter = DetailJoinMembersAdapter(viewModel,currentUserId, studyIdx)  // adapter 초기화
+        adapter = DetailJoinMembersAdapter(viewModel, chatRoomViewModel, currentUserId, studyIdx)  // adapter 초기화
 
 
         return binding.root

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
@@ -14,12 +14,16 @@ import com.bumptech.glide.Glide
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.storage.FirebaseStorage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.RowDetailApplyMemberBinding
 import kr.co.lion.modigm.model.UserData
+import kr.co.lion.modigm.ui.chat.vm.ChatRoomViewModel
 import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
 
-class DetailApplyMembersAdapter (private val viewModel: DetailViewModel, private val currentUserId: String, private val studyIdx: Int) : ListAdapter<UserData, DetailApplyMembersAdapter.MemberViewHolder>(UserDiffCallback()) {
+class DetailApplyMembersAdapter (private val viewModel: DetailViewModel, private val chatRoomViewModel: ChatRoomViewModel, val currentUserId: String, private val studyIdx: Int) : ListAdapter<UserData, DetailApplyMembersAdapter.MemberViewHolder>(UserDiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MemberViewHolder {
         val binding = RowDetailApplyMemberBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -53,6 +57,12 @@ class DetailApplyMembersAdapter (private val viewModel: DetailViewModel, private
                         val textSizeInPx = dpToPx(itemView.context, 16f)
                         textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeInPx)
                         snackbar.show()
+
+                        // 채팅방에 사용자 추가 / chatMemberList 배열에 UID 추가
+                        CoroutineScope(Dispatchers.Main).launch {
+                            val coroutine1 = chatRoomViewModel.addUserToChatMemberList(studyIdx, user.userUid)
+                            coroutine1.join()
+                        }
 
                         // 리스트에서 아이템 제거
                         val position = adapterPosition

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
@@ -16,14 +16,18 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.CustomDialogBinding
 import kr.co.lion.modigm.databinding.RowDetailJoinMemberBinding
 import kr.co.lion.modigm.model.StudyData
 import kr.co.lion.modigm.model.UserData
+import kr.co.lion.modigm.ui.chat.vm.ChatRoomViewModel
 import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
 
-class DetailJoinMembersAdapter(private val viewModel: DetailViewModel,private val currentUserId: String, private val studyIdx: Int) : ListAdapter<UserData, DetailJoinMembersAdapter.MemberViewHolder>(UserDiffCallback()) {
+class DetailJoinMembersAdapter(private val viewModel: DetailViewModel, private val chatRoomViewModel: ChatRoomViewModel, private val currentUserId: String, private val studyIdx: Int) : ListAdapter<UserData, DetailJoinMembersAdapter.MemberViewHolder>(UserDiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MemberViewHolder {
         val binding = RowDetailJoinMemberBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -81,6 +85,11 @@ class DetailJoinMembersAdapter(private val viewModel: DetailViewModel,private va
             dialogBinding.btnYes.setOnClickListener {
                 viewModel.updateStudyUserList(member.userUid, studyIdx)
                 removeItem(position)
+                // 채팅방에 해당 사용자 제거 / chatMemberList 배열에 UID 제거
+                CoroutineScope(Dispatchers.Main).launch {
+                    val coroutine1 = chatRoomViewModel.removeUserFromChatMemberList(studyIdx, member.userUid)
+                    coroutine1.join()
+                }
                 // 예 버튼 로직
                 Log.d("Dialog", "확인을 선택했습니다.")
                 dialog.dismiss()


### PR DESCRIPTION
## #️⃣연관된 이슈

#204

## 📝작업 내용

Detail 페이지에서 멤버 등록 및 내보내기 할 때 채팅 방 멤버에 등록 및 삭제 업데이트 되도록 하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
