### PR TITLE
[#212] Fix  뒤로가기 및 파이어베이스 인증 등록 정보 삭제 로직 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.TextView
 import androidx.activity.addCallback
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -25,6 +26,7 @@ import kr.co.lion.modigm.ui.join.vm.JoinStep1ViewModel
 import kr.co.lion.modigm.ui.join.vm.JoinStep2ViewModel
 import kr.co.lion.modigm.ui.join.vm.JoinStep3ViewModel
 import kr.co.lion.modigm.ui.join.vm.JoinViewModel
+import kr.co.lion.modigm.ui.login.LoginFragment
 import kr.co.lion.modigm.ui.login.OtherLoginFragment
 import kr.co.lion.modigm.ui.study.BottomNaviFragment
 import kr.co.lion.modigm.util.FragmentName
@@ -127,7 +129,13 @@ class JoinFragment : Fragment() {
 
         dialogView.findViewById<TextView>(R.id.btnYes).text = "네"
         dialogView.findViewById<TextView>(R.id.btnYes).setOnClickListener {
-            parentFragmentManager.popBackStack()
+            // 회원가입을 완료하지 않고 화면을 이탈한 경우 이미 등록되어있던 Auth 정보를 삭제한다.
+            if(!viewModel.joinCompleted.value!!){
+                viewModel.deleteCurrentUser()
+            }
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.containerMain, LoginFragment())
+                .commit()
             dialog.dismiss()
         }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
@@ -132,11 +132,10 @@ class JoinViewModel : ViewModel() {
 
     // 회원가입 이탈 시 이미 Auth에 등록되어있는 인증 정보 삭제
     fun deleteCurrentUser(){
-        // 이메일 인증 정보 삭제
-        if(!verifiedEmail.value.isNullOrEmpty()){
-            _user.value?.delete()
+        // 인증 정보 삭제
+        if(_auth.currentUser != null){
+            _auth.currentUser?.delete()
         }
-        // 전화번호 인증 정보는 이미 중복확인을 할 때 삭제해놓기 때문에 필요없음
     }
 
     // UserInfoData 객체 생성


### PR DESCRIPTION
## #️⃣연관된 이슈

> #212 
## 📝작업 내용

> 회원가입에서 로그인 화면으로 뒤로가기 로직 수정 및 파이어베이스 인증에 등록된 정보 삭제하는 로직 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
