### PR TITLE
[#209] feature 등록한 사진이 옆으로 생기도록 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/write/WriteIntroFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/write/WriteIntroFragment.kt
@@ -130,7 +130,8 @@ class WriteIntroFragment : Fragment() {
                 // 크기를 조정한 이미지를 구한다.
                 val bitmap3 = resizeBitmap(bitmap2, 1024)
 
-                fragmentWriteIntroBinding.imageViewWriteIntroCoverImage.setImageBitmap(bitmap3)
+                fragmentWriteIntroBinding.cardViewWriteIntroCreatedCardCover.visibility = View.VISIBLE
+                fragmentWriteIntroBinding.imageViewCoverImageSelect.setImageBitmap(bitmap3)
                 isAddPicture = true
 
                 // 사진 파일을 삭제한다.
@@ -177,7 +178,8 @@ class WriteIntroFragment : Fragment() {
                     // 크기를 줄인 이미지를 가져온다.
                     val bitmap3 = resizeBitmap(bitmap2, 1024)
 
-                    fragmentWriteIntroBinding.imageViewWriteIntroCoverImage.setImageBitmap(bitmap)
+                    fragmentWriteIntroBinding.cardViewWriteIntroCreatedCardCover.visibility = View.VISIBLE
+                    fragmentWriteIntroBinding.imageViewCoverImageSelect.setImageBitmap(bitmap3)
                     isAddPicture = true
                 }
             }

--- a/app/src/main/res/drawable/icon_photo_plus_24px.xml
+++ b/app/src/main/res/drawable/icon_photo_plus_24px.xml
@@ -1,9 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="30" android:viewportWidth="30" android:width="24dp">
       
-    <path android:fillColor="#00000000" android:pathData="M18.75,10H18.763M15.625,26.25H7.5C6.505,26.25 5.552,25.855 4.848,25.152C4.145,24.448 3.75,23.495 3.75,22.5V7.5C3.75,6.505 4.145,5.552 4.848,4.848C5.552,4.145 6.505,3.75 7.5,3.75H22.5C23.495,3.75 24.448,4.145 25.152,4.848C25.855,5.552 26.25,6.505 26.25,7.5V15.625" android:strokeColor="#000000" android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="2"/>
+    <path android:fillColor="#00000000" android:pathData="M18.75,10H18.763M15.625,26.25H7.5C6.505,26.25 5.552,25.855 4.848,25.152C4.145,24.448 3.75,23.495 3.75,22.5V7.5C3.75,6.505 4.145,5.552 4.848,4.848C5.552,4.145 6.505,3.75 7.5,3.75H22.5C23.495,3.75 24.448,4.145 25.152,4.848C25.855,5.552 26.25,6.505 26.25,7.5V15.625" android:strokeColor="#777777" android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="2"/>
       
-    <path android:fillColor="#00000000" android:pathData="M3.75,19.999L10,13.749C11.16,12.633 12.59,12.633 13.75,13.749L18.75,18.749" android:strokeColor="#000000" android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="2"/>
+    <path android:fillColor="#00000000" android:pathData="M3.75,19.999L10,13.749C11.16,12.633 12.59,12.633 13.75,13.749L18.75,18.749" android:strokeColor="#777777" android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="2"/>
       
-    <path android:fillColor="#00000000" android:pathData="M17.5,17.5L18.75,16.25C19.587,15.445 20.563,15.22 21.478,15.575M20,23.75H27.5M23.75,20V27.5" android:strokeColor="#000000" android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="2"/>
+    <path android:fillColor="#00000000" android:pathData="M17.5,17.5L18.75,16.25C19.587,15.445 20.563,15.22 21.478,15.575M20,23.75H27.5M23.75,20V27.5" android:strokeColor="#777777" android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="2"/>
     
 </vector>

--- a/app/src/main/res/drawable/icon_photo_plus_24px.xml
+++ b/app/src/main/res/drawable/icon_photo_plus_24px.xml
@@ -1,9 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="30" android:viewportWidth="30" android:width="24dp">
       
-    <path android:fillColor="#00000000" android:pathData="M18.75,10H18.763M15.625,26.25H7.5C6.505,26.25 5.552,25.855 4.848,25.152C4.145,24.448 3.75,23.495 3.75,22.5V7.5C3.75,6.505 4.145,5.552 4.848,4.848C5.552,4.145 6.505,3.75 7.5,3.75H22.5C23.495,3.75 24.448,4.145 25.152,4.848C25.855,5.552 26.25,6.505 26.25,7.5V15.625" android:strokeColor="#777777" android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="2"/>
+    <path android:fillColor="#00000000" android:pathData="M18.75,10H18.763M15.625,26.25H7.5C6.505,26.25 5.552,25.855 4.848,25.152C4.145,24.448 3.75,23.495 3.75,22.5V7.5C3.75,6.505 4.145,5.552 4.848,4.848C5.552,4.145 6.505,3.75 7.5,3.75H22.5C23.495,3.75 24.448,4.145 25.152,4.848C25.855,5.552 26.25,6.505 26.25,7.5V15.625" android:strokeColor="#000000" android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="2"/>
       
-    <path android:fillColor="#00000000" android:pathData="M3.75,19.999L10,13.749C11.16,12.633 12.59,12.633 13.75,13.749L18.75,18.749" android:strokeColor="#777777" android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="2"/>
+    <path android:fillColor="#00000000" android:pathData="M3.75,19.999L10,13.749C11.16,12.633 12.59,12.633 13.75,13.749L18.75,18.749" android:strokeColor="#000000" android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="2"/>
       
-    <path android:fillColor="#00000000" android:pathData="M17.5,17.5L18.75,16.25C19.587,15.445 20.563,15.22 21.478,15.575M20,23.75H27.5M23.75,20V27.5" android:strokeColor="#777777" android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="2"/>
+    <path android:fillColor="#00000000" android:pathData="M17.5,17.5L18.75,16.25C19.587,15.445 20.563,15.22 21.478,15.575M20,23.75H27.5M23.75,20V27.5" android:strokeColor="#000000" android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="2"/>
     
 </vector>

--- a/app/src/main/res/layout/fragment_write_intro.xml
+++ b/app/src/main/res/layout/fragment_write_intro.xml
@@ -43,6 +43,7 @@
                     android:id="@+id/cardview_writeIntro_cardCover"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    app:cardCornerRadius="16dp"
                     android:layout_marginStart="16dp"
                     android:layout_marginTop="16dp"
                     android:backgroundTint="@color/white"

--- a/app/src/main/res/layout/fragment_write_intro.xml
+++ b/app/src/main/res/layout/fragment_write_intro.xml
@@ -47,19 +47,45 @@
                     android:layout_marginTop="16dp"
                     android:backgroundTint="@color/white"
                     app:layout_constraintStart_toStartOf="parent"
-
+                    app:strokeWidth="2dp"
                     app:layout_constraintTop_toBottomOf="@id/textView_writeIntro_cover"
-                    app:strokeColor="@color/black">
+                    app:strokeColor="@color/textGray">
 
                     <ImageView
                         android:id="@+id/imageView_writeIntro_coverImage"
                         style="@style/Widget.Material3.MaterialTimePicker.ImageButton"
-                        android:layout_width="60dp"
-                        android:layout_height="60dp"
+                        android:layout_width="70dp"
+                        android:layout_height="70dp"
                         android:adjustViewBounds="true"
                         android:backgroundTint="@color/white"
-                        android:padding="14dp"
+                        android:padding="20dp"
+                        android:scaleType="centerCrop"
                         app:srcCompat="@drawable/icon_photo_plus_24px" />
+                </com.google.android.material.circularreveal.cardview.CircularRevealCardView>
+
+                <com.google.android.material.circularreveal.cardview.CircularRevealCardView
+                    android:id="@+id/cardView_writeIntro_createdCardCover"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:visibility="invisible"
+                    app:cardCornerRadius="16dp"
+                    app:cardBackgroundColor="@color/white"
+                    app:cardElevation="0dp"
+                    android:layout_marginStart="10dp"
+                    app:strokeColor="@color/textGray"
+                    app:strokeWidth="2dp"
+                    android:layout_marginTop="16dp"
+                    app:layout_constraintTop_toBottomOf="@id/textView_writeIntro_cover"
+                    app:layout_constraintStart_toEndOf="@id/cardview_writeIntro_cardCover">
+
+
+                    <ImageView
+                        android:id="@+id/imageViewCoverImageSelect"
+                        android:layout_width="70dp"
+                        android:layout_height="70dp"
+                        android:scaleType="centerCrop"
+                        android:src="@drawable/image_detail_2" />
+
                 </com.google.android.material.circularreveal.cardview.CircularRevealCardView>
 
                 <TextView


### PR DESCRIPTION
## #️⃣연관된 이슈

> #209
## 📝작업 내용

> 글작성 소개 탭에서 사진등록시 옆에 새로운 카드뷰가 생성되도록 수정(Detail Edit Fragment과 통일)

### 스크린샷 (선택)

<img width="323" alt="스크린샷 2024-06-11 오후 1 36 09" src="https://github.com/APP-Android2/FinalProject-modigm/assets/128672219/68c610bd-b7a4-479d-8b1b-e771b2215240">