### PR TITLE
#205 fix: 프로필 수정 시 UI 업데이트

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/EditProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/EditProfileFragment.kt
@@ -29,12 +29,14 @@ import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentEditProfileBinding
 import kr.co.lion.modigm.ui.profile.adapter.LinkAddAdapter
 import kr.co.lion.modigm.ui.profile.vm.EditProfileViewModel
+import kr.co.lion.modigm.ui.profile.vm.ProfileViewModel
 import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.Interest
 import kr.co.lion.modigm.util.JoinType
+import kr.co.lion.modigm.util.ModigmApplication
 import kr.co.lion.modigm.util.Picture
 
-class EditProfileFragment : Fragment() {
+class EditProfileFragment(private val profileFragment: ProfileFragment) : Fragment() {
     lateinit var fragmentEditProfileBinding: FragmentEditProfileBinding
     private val editProfileViewModel: EditProfileViewModel by activityViewModels()
 
@@ -117,8 +119,14 @@ class EditProfileFragment : Fragment() {
 
     private fun setupButtonDone() {
         fragmentEditProfileBinding.buttonEditProfileDone.setOnClickListener {
-            editProfileViewModel.updateUserData()
-            requireActivity().supportFragmentManager.popBackStack()
+            viewLifecycleOwner.lifecycleScope.launch {
+                editProfileViewModel.updateUserData(profileFragment)
+                Log.d("zunione", "${ModigmApplication.prefs.getUserData("currentUserData")}")
+                requireActivity().supportFragmentManager.popBackStack()
+            }
+//            editProfileViewModel.updateUserData()
+//            profileFragment.updateViews()
+//            requireActivity().supportFragmentManager.popBackStack()
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/EditProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/EditProfileFragment.kt
@@ -79,7 +79,7 @@ class EditProfileFragment : Fragment() {
     private fun setupToolbar() {
         fragmentEditProfileBinding.toolbarEditProfile.apply {
             setNavigationOnClickListener {
-                parentFragmentManager.popBackStack(FragmentName.EDIT_PROFILE.str, 0)
+                requireActivity().supportFragmentManager.popBackStack()
             }
         }
     }
@@ -118,7 +118,7 @@ class EditProfileFragment : Fragment() {
     private fun setupButtonDone() {
         fragmentEditProfileBinding.buttonEditProfileDone.setOnClickListener {
             editProfileViewModel.updateUserData()
-            parentFragmentManager.popBackStack(FragmentName.EDIT_PROFILE.str, 0)
+            requireActivity().supportFragmentManager.popBackStack()
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
@@ -29,7 +30,7 @@ import kr.co.lion.modigm.util.ModigmApplication
 
 class ProfileFragment: Fragment() {
     lateinit var fragmentProfileBinding: FragmentProfileBinding
-    private val profileViewModel: ProfileViewModel by viewModels()
+    private val profileViewModel: ProfileViewModel by activityViewModels()
 
     // onCreateView에서 초기화
     var uid: String? = null
@@ -131,6 +132,10 @@ class ProfileFragment: Fragment() {
         initView()
     }
 
+    fun updateViews() {
+        setupUserInfo()
+    }
+
     private fun initView() {
         setupToolbar()
         setupFab()
@@ -155,7 +160,7 @@ class ProfileFragment: Fragment() {
                         R.id.menu_item_profile_setting -> {
                             requireActivity().supportFragmentManager.commit {
                                 setCustomAnimations(R.anim.slide_in, R.anim.fade_out, R.anim.fade_in, R.anim.slide_out)
-                                add(R.id.containerMain, SettingsFragment())
+                                add(R.id.containerMain, SettingsFragment(this@ProfileFragment))
                                 addToBackStack(FragmentName.SETTINGS.str)
                             }
                         }
@@ -211,6 +216,7 @@ class ProfileFragment: Fragment() {
     }
 
     private fun setupUserInfo() {
+        Log.d("zunione", "setupUserInfo")
         profileViewModel.profileUid.value = uid
         profileViewModel.loadUserData(requireContext(), fragmentProfileBinding.imageProfilePic)
         profileViewModel.loadPartStudyList(uid!!)
@@ -260,6 +266,9 @@ class ProfileFragment: Fragment() {
         // 데이터 변경 관찰
         // 관심 분야 chipGroup
         profileViewModel.profileInterestList.observe(viewLifecycleOwner, Observer { list ->
+            // 기존 칩들 제거
+            fragmentProfileBinding.chipGroupProfile.removeAllViews()
+
             // 리스트가 변경될 때마다 for 문을 사용하여 아이템을 처리
             for (interestNum in list) {
                 // 아이템 처리 코드

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -181,10 +181,7 @@ class ProfileFragment: Fragment() {
                     // 뒤로 가기
                     setNavigationIcon(R.drawable.icon_arrow_back_24px)
                     setNavigationOnClickListener {
-                        parentFragmentManager.beginTransaction()
-                            .replace(R.id.containerMain, SettingsFragment())
-                            .addToBackStack(FragmentName.FILTER_SORT.str)
-                            .commit()
+                        parentFragmentManager.popBackStack()
                     }
 
                     // 더보기 아이콘 표시

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/SettingsFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/SettingsFragment.kt
@@ -18,7 +18,7 @@ import kr.co.lion.modigm.ui.login.LoginFragment
 import kr.co.lion.modigm.ui.study.BottomNaviFragment
 import kr.co.lion.modigm.util.FragmentName
 
-class SettingsFragment : Fragment() {
+class SettingsFragment(private val profileFragment: ProfileFragment) : Fragment() {
     lateinit var fragmentSettingsBinding: FragmentSettingsBinding
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -67,7 +67,7 @@ class SettingsFragment : Fragment() {
             // 회원 정보 수정
             layoutSettingsEditInfo.setOnClickListener {
                 parentFragmentManager.beginTransaction()
-                    .add(R.id.containerMain, EditProfileFragment())
+                    .add(R.id.containerMain, EditProfileFragment(profileFragment))
                     .addToBackStack(FragmentName.EDIT_PROFILE.str)
                     .commit()
             }

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/vm/EditProfileViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/vm/EditProfileViewModel.kt
@@ -3,6 +3,7 @@ package kr.co.lion.modigm.ui.profile.vm
 import android.content.Context
 import android.util.Log
 import android.widget.ImageView
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -15,6 +16,7 @@ import kotlinx.coroutines.launch
 import kr.co.lion.modigm.model.UserData
 import kr.co.lion.modigm.repository.StudyRepository
 import kr.co.lion.modigm.repository.UserInfoRepository
+import kr.co.lion.modigm.ui.profile.ProfileFragment
 import kr.co.lion.modigm.util.Interest
 import kr.co.lion.modigm.util.JoinType
 import kr.co.lion.modigm.util.ModigmApplication
@@ -103,7 +105,7 @@ class EditProfileViewModel: ViewModel() {
         _editProfileLinkList.value = _editProfileLinkList.value?.filter { it != link }
     }
 
-    fun updateUserData() = viewModelScope.launch {
+    fun updateUserData(profileFragment: ProfileFragment) = viewModelScope.launch {
         val user = UserData()
         user.userUid = ModigmApplication.prefs.getUserData("currentUserData")?.userUid!!
         user.userName = ModigmApplication.prefs.getUserData("currentUserData")?.userName!!
@@ -118,5 +120,8 @@ class EditProfileViewModel: ViewModel() {
         userRepository.updateUserData(user)
         ModigmApplication.prefs.clearUserData("currentUserData")
         ModigmApplication.prefs.setUserData("currentUserData", user)
+
+        // 프로필 화면 업데이트
+        profileFragment.updateViews()
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#205 

## 📝작업 내용

1. 타인의 프로필을 볼 때 뒤로 가기 버튼을 누르면 설정 화면으로 이동하는 오류 해결
2. 프로필 수정 후 프로필 화면으로 돌아가면 화면이 업데이트되지 않는 문제 해결
  -> profileFragment 객체를 전달해 업데이트 함수 호출