### PR TITLE
[#215] [Feature] 스터디 검색 기능 구현

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/study/StudyAllFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/StudyAllFragment.kt
@@ -110,6 +110,15 @@ class StudyAllFragment : Fragment(R.layout.fragment_study_all) {
                 layoutManager = LinearLayoutManager(requireActivity())
             }
 
+            with(searchBarStudyAll){
+                setOnClickListener{
+                    requireActivity().supportFragmentManager.commit {
+                        add(R.id.containerMain,StudySearchFragment())
+                        addToBackStack(FragmentName.STUDY_SEARCH.str)
+                    }
+                }
+            }
+
         }
     }
     private fun observeData() {

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/StudySearchFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/StudySearchFragment.kt
@@ -3,7 +3,6 @@ package kr.co.lion.modigm.ui.study
 import android.graphics.Color
 import android.os.Bundle
 import android.view.View
-import android.widget.ImageView
 import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/StudySearchFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/StudySearchFragment.kt
@@ -91,8 +91,6 @@ class StudySearchFragment : Fragment(R.layout.fragment_study_search) {
             recyclerViewStudySearch.layoutManager = LinearLayoutManager(requireContext())
             recyclerViewStudySearch.adapter = studySearchAdapter
 
-            val searchIcon = searchView.findViewById<ImageView>(androidx.appcompat.R.id.search_mag_icon)
-            searchIcon?.visibility = View.GONE
             toolbarStudySearch.setNavigationOnClickListener{
                 parentFragmentManager.popBackStack()
             }

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/StudySearchFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/StudySearchFragment.kt
@@ -3,25 +3,30 @@ package kr.co.lion.modigm.ui.study
 import android.graphics.Color
 import android.os.Bundle
 import android.view.View
+import android.widget.ImageView
+import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
 import androidx.lifecycle.viewModelScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.launch
 import kr.co.lion.modigm.R
-import kr.co.lion.modigm.databinding.FragmentStudyMyBinding
+import kr.co.lion.modigm.databinding.FragmentStudySearchBinding
 import kr.co.lion.modigm.databinding.RowStudyMyBinding
 import kr.co.lion.modigm.ui.detail.DetailFragment
-import kr.co.lion.modigm.ui.study.adapter.StudyMyAdapter
+import kr.co.lion.modigm.ui.study.adapter.StudySearchAdapter
 import kr.co.lion.modigm.ui.study.vm.StudyViewModel
 import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.ModigmApplication
 
+class StudySearchFragment : Fragment(R.layout.fragment_study_search) {
 
-class StudyMyFragment : Fragment(R.layout.fragment_study_my) {
+    private var _binding: FragmentStudySearchBinding? = null
+    private val binding get() = _binding!!
 
     private lateinit var rowbinding: RowStudyMyBinding
 
@@ -30,8 +35,7 @@ class StudyMyFragment : Fragment(R.layout.fragment_study_my) {
 
     private val currentUserUid = ModigmApplication.prefs.getUserData("currentUserData")?.userUid ?: Firebase.auth.currentUser?.uid ?: ""
 
-    // 어답터
-    private val studyMyAdapter: StudyMyAdapter = StudyMyAdapter(
+    private val studySearchAdapter: StudySearchAdapter = StudySearchAdapter(
         // 최초 리스트
         emptyList(),
 
@@ -70,58 +74,51 @@ class StudyMyFragment : Fragment(R.layout.fragment_study_my) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val binding = FragmentStudyMyBinding.bind(view)
+        _binding = FragmentStudySearchBinding.bind(view)
         rowbinding = RowStudyMyBinding.inflate(layoutInflater)
 
-        // 초기 뷰 세팅
         initView(binding)
-        observeData()
+
+        viewModel.studyStateTrueDataList.observe(viewLifecycleOwner, Observer { studyList ->
+            studySearchAdapter.updateData(studyList)
+        })
     }
 
-    // 초기 뷰 세팅
-    fun initView(binding: FragmentStudyMyBinding) {
+    private fun initView(binding: FragmentStudySearchBinding) {
 
-        with(binding){
+        with(binding) {
+            // RecyclerView 설정
+            recyclerViewStudySearch.layoutManager = LinearLayoutManager(requireContext())
+            recyclerViewStudySearch.adapter = studySearchAdapter
 
+            val searchIcon = searchView.findViewById<ImageView>(androidx.appcompat.R.id.search_mag_icon)
+            searchIcon?.visibility = View.GONE
+            toolbarStudySearch.setNavigationOnClickListener{
+                parentFragmentManager.popBackStack()
+            }
 
-            // 필터 버튼
-            with(imageViewStudyMyFilter){
-                // 클릭 시
-                setOnClickListener {
-                    // 필터 및 정렬 화면으로 이동
-                    requireActivity().supportFragmentManager.commit {
-                        replace(R.id.containerMain, FilterSortFragment())
-                        addToBackStack(FragmentName.FILTER_SORT.str)
+            // init SearchView
+            searchView.isSubmitButtonEnabled = true
+            searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+                override fun onQueryTextSubmit(query: String?): Boolean {
+                    query?.let {
+                        studySearchAdapter.filter(it)
                     }
+                    return false
                 }
-            }
 
-            // 리사이클러뷰
-            with(recyclerViewStudyMy) {
-                // 리사이클러뷰 어답터
-
-
-                adapter = studyMyAdapter
-
-                // 리사이클러뷰 레이아웃
-                layoutManager = LinearLayoutManager(requireActivity())
-            }
-
-            with(searchBarStudyMy){
-                setOnClickListener{
-                    requireActivity().supportFragmentManager.commit {
-                        add(R.id.containerMain,StudySearchFragment())
-                        addToBackStack(FragmentName.STUDY_SEARCH.str)
+                override fun onQueryTextChange(newText: String?): Boolean {
+                    newText?.let {
+                        studySearchAdapter.filter(it)
                     }
+                    return true
                 }
-            }
+            })
         }
     }
 
-    private fun observeData() {
-        // 데이터 변경 관찰
-        viewModel.studyMyDataList.observe(viewLifecycleOwner) { studyList ->
-            studyMyAdapter.updateData(studyList)
-        }
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudySearchAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudySearchAdapter.kt
@@ -1,0 +1,57 @@
+package kr.co.lion.modigm.ui.study.adapter
+
+import android.annotation.SuppressLint
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import kr.co.lion.modigm.databinding.RowStudyMyBinding
+import kr.co.lion.modigm.model.StudyData
+
+class StudySearchAdapter(
+    private var studyList: List<Pair<StudyData, Int>>,
+    // 항목 1개 클릭 리스너
+    private val rowClickListener: (Int) -> Unit,
+    private val likeClickListener: (Int) -> Unit,
+) : RecyclerView.Adapter<StudySearchViewHolder>() {
+
+    private var filteredList: List<Pair<StudyData, Int>> = studyList
+
+    override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): StudySearchViewHolder {
+        val binding: RowStudyMyBinding =
+            RowStudyMyBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false)
+        return StudySearchViewHolder(
+            binding,
+            rowClickListener,
+            likeClickListener,
+        )
+    }
+
+    override fun getItemCount(): Int {
+        return filteredList.size
+    }
+
+    override fun onBindViewHolder(holder: StudySearchViewHolder, position: Int) {
+        holder.bind(filteredList[position])
+    }
+
+    // 데이터 필터링
+    @SuppressLint("NotifyDataSetChanged")
+    fun filter(query: String) {
+        filteredList = if (query.isEmpty()) {
+            emptyList() // 검색어가 빈 문자열일 때 빈 리스트로 설정
+        } else {
+            studyList.filter { it.first.studyTitle.contains(query, ignoreCase = true) }
+        }
+        notifyDataSetChanged()
+        Log.d("update adapter", filteredList.toString())
+    }
+
+    // 목록 새로고침
+    @SuppressLint("NotifyDataSetChanged")
+    fun updateData(list: List<Pair<StudyData, Int>>) {
+        studyList = list
+        notifyDataSetChanged()
+        Log.d("update adapter", list.toString())
+    }
+}

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudySearchAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudySearchAdapter.kt
@@ -47,6 +47,7 @@ class StudySearchAdapter(
         Log.d("update adapter", filteredList.toString())
     }
 
+
     // 목록 새로고침
     @SuppressLint("NotifyDataSetChanged")
     fun updateData(list: List<Pair<StudyData, Int>>) {

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudySearchViewHolder.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/adapter/StudySearchViewHolder.kt
@@ -1,0 +1,178 @@
+package kr.co.lion.modigm.ui.study.adapter
+
+import android.graphics.Color
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.google.firebase.storage.FirebaseStorage
+import kr.co.lion.modigm.R
+import kr.co.lion.modigm.databinding.RowStudyMyBinding
+import kr.co.lion.modigm.model.StudyData
+
+class StudySearchViewHolder(
+    private val binding: RowStudyMyBinding,
+    private val rowClickListener: (Int) -> Unit,
+    private val likeClickListener: (Int) -> Unit,
+    ):RecyclerView.ViewHolder(binding.root){
+
+    // 전체 스터디 항목별 세팅
+    fun bind(studyData: Pair<StudyData, Int>) {
+        with(binding) {
+            // 루트 뷰의 레이아웃 설정 및 클릭 리스너 설정
+            setupRootView(studyData)
+
+            // 스터디 사진 설정
+            loadStudyImage(studyData.first.studyPic)
+
+            // 스터디 상태 설정 (모집중/모집완료)
+            setStudyState(studyData.first.studyState)
+
+            // 스터디 진행 방식 설정 (온라인/오프라인/혼합)
+            setStudyOnOffline(studyData.first.studyOnOffline)
+
+            // 스터디 제목 설정
+            textViewStudyMyTitle.text = studyData.first.studyTitle
+
+            // 스터디 기간 설정 (스터디/프로젝트/공모전)
+            setStudyPeriod(studyData.first.studyPeriod)
+
+            // 스터디 인원 설정
+            setStudyMembers(studyData)
+
+            // 스터디 신청 방식 설정
+            setStudyApplyMethod(studyData)
+
+            // 찜 버튼 설정
+            setupFavoriteButton(studyData)
+        }
+    }
+
+    // 루트 뷰의 레이아웃 설정 및 클릭 리스너 설정
+    private fun setupRootView(studyData: Pair<StudyData, Int>) {
+        with(binding.root) {
+            // 루트 뷰의 레이아웃 파라미터 설정
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+
+            // 루트 뷰 클릭 리스너 설정
+            setOnClickListener {
+                rowClickListener.invoke(studyData.first.studyIdx)
+            }
+
+            // 스터디 이미지 클릭 리스너 설정 (현재는 빈 구현)
+            binding.imageViewStudyMyPic.setOnClickListener {
+                // 클릭 시 실행될 코드 (현재는 빈 구현)
+            }
+        }
+    }
+
+    // Firebase Storage에서 스터디 이미지 로드
+    private fun loadStudyImage(imageFileName: String) {
+        if (imageFileName.isNotEmpty()) {
+            val storageRef = FirebaseStorage.getInstance().reference.child("studyPic/$imageFileName")
+            storageRef.downloadUrl.addOnSuccessListener { uri ->
+                Glide.with(itemView.context)
+                    .load(uri)
+                    .into(binding.imageViewStudyMyPic)
+            }.addOnFailureListener {
+                // 실패 시 기본 이미지 설정 또는 에러 처리
+                binding.imageViewStudyMyPic.setImageResource(R.drawable.image_detail_1)
+            }
+        } else {
+            binding.imageViewStudyMyPic.setImageResource(R.drawable.image_detail_2)
+        }
+    }
+
+    // 스터디 상태 설정 (모집중/모집완료)
+    private fun setStudyState(studyState: Boolean) {
+        // 스터디 상태에 따라 텍스트를 설정
+        binding.textViewStudyMyCanApply.text = if (studyState) "모집중" else "모집 완료"
+    }
+
+    // 스터디 진행 방식 설정 (온라인/오프라인/혼합)
+    private fun setStudyOnOffline(studyOnOffline: Int) {
+        with(binding.textViewStudyMyOnOffline) {
+            // 스터디 진행 방식에 따라 텍스트와 텍스트 색상을 설정
+            when (studyOnOffline) {
+                1 -> {
+                    text = "온라인"
+                    setTextColor(android.graphics.Color.parseColor("#0FA981"))
+                }
+                2 -> {
+                    text = "오프라인"
+                    setTextColor(android.graphics.Color.parseColor("#EB9C58"))
+                }
+                3 -> {
+                    text = "온오프혼합"
+                    setTextColor(android.graphics.Color.parseColor("#0096FF"))
+                }
+            }
+        }
+    }
+
+    // 스터디 기간 설정 (스터디/프로젝트/공모전)
+    private fun setStudyPeriod(studyPeriod: Int) {
+        with(binding.textViewStudyMyType) {
+            // 스터디 기간에 따라 텍스트를 설정
+            when (studyPeriod) {
+                1 -> {
+                    text = "스터디"
+                }
+                2 -> {
+                    text = "프로젝트"
+                }
+                else -> {
+                    text = "공모전"
+                }
+            }
+        }
+    }
+
+    // 스터디 인원 설정
+    private fun setStudyMembers(studyData: Pair<StudyData, Int>) {
+        // 스터디 최대 인원과 현재 인원을 설정
+        binding.textViewStudyMyMaxMember.text = studyData.first.studyMaxMember.toString()
+        binding.textViewStudyMyCurrentMember.text = studyData.second.toString()
+    }
+
+    // 스터디 신청 방식 설정
+    private fun setStudyApplyMethod(studyData: Pair<StudyData, Int>) {
+        with(binding){
+            textViewStudyMyApplyMethod.text = when(studyData.first.studyApplyMethod){
+                1 -> "선착순"
+                2 -> "신청제"
+                else -> ""
+            }
+        }
+    }
+
+    // 찜 버튼 설정
+    private fun setupFavoriteButton(studyData: Pair<StudyData, Int>) {
+        with(binding.imageViewStudyMyFavorite) {
+            // 초기 좋아요 상태 설정
+            if (studyData.first.studyLikeState) {
+                setImageResource(R.drawable.icon_favorite_full_24px)
+                setColorFilter(Color.parseColor("#D73333"))
+            } else {
+                setImageResource(R.drawable.icon_favorite_24px)
+                clearColorFilter()
+            }
+
+            // 클릭 리스너 설정
+            setOnClickListener {
+                likeClickListener.invoke(studyData.first.studyIdx)
+                // 좋아요 상태 변경 후 UI 업데이트
+                studyData.first.studyLikeState = !studyData.first.studyLikeState
+                if (studyData.first.studyLikeState) {
+                    setImageResource(R.drawable.icon_favorite_full_24px)
+                    setColorFilter(Color.parseColor("#D73333"))
+                } else {
+                    setImageResource(R.drawable.icon_favorite_24px)
+                    clearColorFilter()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/kr/co/lion/modigm/util/FragmentName.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/FragmentName.kt
@@ -46,6 +46,7 @@ enum class FragmentName (var str: String){
     STUDY_MY("StudyMyFragment"),
     FILTER_SORT("FilterSortFragment"),
     BOTTOM_NAVI("BottomNaviFragment"),
+    STUDY_SEARCH("StudySearchFragment"),
 
 
     // 글 작성

--- a/app/src/main/res/layout/fragment_study_search.xml
+++ b/app/src/main/res/layout/fragment_study_search.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/white"
+    tools:context=".ui.study.StudySearchFragment">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbarStudySearch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:navigationIcon="@drawable/icon_back_24px"
+        app:title="스터디 검색"
+        app:titleTextAppearance="@style/toolbarText"
+        app:titleCentered="true">
+
+    </com.google.android.material.appbar.MaterialToolbar>
+    <androidx.appcompat.widget.SearchView
+        android:id="@+id/searchView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:focusable="true"
+        app:iconifiedByDefault="false"
+        app:hideNavigationIcon="true"
+        app:queryHint="검색할 스터디 제목을 입력하세요" />
+
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewStudySearch"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="16dp" />
+
+</LinearLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #215 

## 📝작업 내용

스터디 검색기능 구현입니다.

### 스크린샷 (선택)
<img width="320" alt="image" src="https://github.com/APP-Android2/FinalProject-modigm/assets/79239041/62fd9ff0-ec68-4cf6-a27e-623849b099cc">

## 💬리뷰 요구사항(선택)

서치뷰에 앞에 있는 아이콘은 이미 기능이 있어서 그런지 그걸 막고 새로운 클릭 리스너를 적용을 못하더군요. 
서치뷰를 구현을 다해놓고 툴바에 집어넣으려했더니 아이콘중첩을 없앨수가 없어서 그냥 이렇게 만들었습니다 ..ㅜ (서치바로 할껄) 
글자변경감지로 넣어서 바로바로 나오게, 다 지우면 다시 빈 리스트 반영하게 해놨습니다.