### PR TITLE
[#272] bug 전화번호 인증 계정 중복 확인 기능 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/db/join/RemoteJoinUserDao.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/join/RemoteJoinUserDao.kt
@@ -114,4 +114,27 @@ class RemoteJoinUserDao {
             }
         }
 
+    suspend fun checkUserByPhone(phone: String): Result<Map<String, String>?>
+        = withContext(Dispatchers.IO) {
+            runCatching {
+                var preparedStatement: PreparedStatement?
+                var resultMap: MutableMap<String, String>? = mutableMapOf()
+                val sql = "SELECT userEmail, userProvider FROM tb_user WHERE userPhone = ?"
+                getConnection().use { connection ->
+                    preparedStatement = connection.prepareStatement(sql) // PreparedStatement 생성
+                    preparedStatement?.setString(1, phone)
+                    val resultSet = preparedStatement?.executeQuery() // 쿼리 실행
+                    val hasRow = resultSet?.next()
+                    if(hasRow == true){
+                        resultMap?.set("userEmail", resultSet.getString("userEmail"))
+                        resultMap?.set("userProvider", resultSet.getString("userProvider"))
+                    }else{
+                        resultMap = null
+                    }
+                }
+                resultMap
+            }.onFailure { e ->
+                Log.e(TAG, "Error in checkUserByPhone", e) // 오류 로그 출력
+            }
+    }
 }

--- a/app/src/main/java/kr/co/lion/modigm/db/join/RemoteJoinUserDataSource.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/join/RemoteJoinUserDataSource.kt
@@ -10,6 +10,10 @@ class RemoteJoinUserDataSource {
     suspend fun insetUserData(userInfoData: SqlUserData): Result<Int>
         = dao.insertUserData(userInfoData.toMap())
 
+    // 해당 전화 번호의 계정이 있는지 확인 (중복 확인)
+    suspend fun checkUserByPhone(phone: String): Result<Map<String, String>?>
+        = dao.checkUserByPhone(phone)
+
     suspend fun closeConn(){
         dao.closeConn()
     }

--- a/app/src/main/java/kr/co/lion/modigm/repository/JoinUserRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/JoinUserRepository.kt
@@ -10,6 +10,10 @@ class JoinUserRepository {
     suspend fun insetUserData(userInfoData: SqlUserData): Result<Int>
         = _joinUserDataSource.insetUserData(userInfoData)
 
+    // 해당 전화 번호의 계정이 있는지 확인 (중복 확인)
+    suspend fun checkUserByPhone(phoneNumber: String): Result<Map<String, String>?>
+        = _joinUserDataSource.checkUserByPhone(phoneNumber)
+
     // 리소스를 해제하는 메서드 추가
     suspend fun closeConn() {
         _joinUserDataSource.closeConn()

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -16,7 +16,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
-import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.launch
 import kr.co.lion.modigm.R
@@ -34,7 +33,6 @@ import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.JoinType
 import kr.co.lion.modigm.util.hideSoftInput
 
-@AndroidEntryPoint
 class JoinFragment : DBBaseFragment<FragmentJoinBinding>(R.layout.fragment_join) {
 
     private val viewModel: JoinViewModel by viewModels()

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
@@ -13,7 +13,7 @@ import com.google.firebase.auth.PhoneAuthProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.tasks.await
-import kr.co.lion.modigm.repository.UserInfoRepository
+import kr.co.lion.modigm.repository.JoinUserRepository
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 
@@ -90,7 +90,7 @@ class JoinStep2ViewModel: ViewModel() {
 
     private val _auth = FirebaseAuth.getInstance()
 
-    private val _db = UserInfoRepository()
+    private val _db = JoinUserRepository()
 
     private val _authButtonText = MutableStateFlow("인증하기")
     val authButtonText: StateFlow<String> = _authButtonText
@@ -148,10 +148,12 @@ class JoinStep2ViewModel: ViewModel() {
         // DB에 해당 번호로 등록된 계정이 있는지 확인한다.
         val checkResult = _db.checkUserByPhone(userPhone.value)
 
-        if(checkResult != null){
-            _errorMessage.value = "이미 해당 번호로 가입한 계정이 있습니다."
-            _alreadyRegisteredUserProvider.value = checkResult["provider"] ?: ""
-            _alreadyRegisteredUserEmail.value = checkResult["email"] ?: ""
+        checkResult.onSuccess { resultMap ->
+            if(resultMap != null){
+                _errorMessage.value = "이미 해당 번호로 가입한 계정이 있습니다."
+                _alreadyRegisteredUserProvider.value = resultMap["userProvider"] ?: ""
+                _alreadyRegisteredUserEmail.value = resultMap["userEmail"] ?: ""
+            }
             return _errorMessage.value
         }
         // 오류 메시지


### PR DESCRIPTION
## #️⃣연관된 이슈

> #272 

## 📝작업 내용

> 전화번호 인증 계정 중복 확인 기능이 안되는 부분을 확인했고 중복 확인을 파이어스토어에서 체크하는 것에서 mysql에서 체크하는 것으로 수정했습니다.

> 테스트로 Hilt 어노테이션 붙여두었던 것을 미처 지우지 않아 실행 시 에러가 발생하여 삭제했습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
