### PR TITLE
[#281] bug  전화번호 계정 중복 확인 코드 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
@@ -153,8 +153,8 @@ class JoinStep2ViewModel: ViewModel() {
                 _errorMessage.value = "이미 해당 번호로 가입한 계정이 있습니다."
                 _alreadyRegisteredUserProvider.value = resultMap["userProvider"] ?: ""
                 _alreadyRegisteredUserEmail.value = resultMap["userEmail"] ?: ""
+                return _errorMessage.value
             }
-            return _errorMessage.value
         }
         // 오류 메시지
         if(_isCodeSent.value){
@@ -173,7 +173,6 @@ class JoinStep2ViewModel: ViewModel() {
                 _auth.currentUser?.linkWithCredential(phoneCredential)?.await()
             }catch (e: FirebaseAuthException){
                 _errorMessage.value = e.message.toString()
-                e.errorCode
                 inputSmsCodeValidation.value = _errorMessage.value
             }
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #281

## 📝작업 내용

> 회원가입 진행 시 전화번호 계정이 이메일(SNS)계정과 통합되지 않는 버그를 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
