### PR TITLE
[#278] [Refactor] 전화번호 및 비밀번호 변경하기 리팩토링

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/study/BottomNaviFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/BottomNaviFragment.kt
@@ -5,11 +5,13 @@ import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
+import androidx.fragment.app.viewModels
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentBottomNaviBinding
 import kr.co.lion.modigm.ui.VBBaseFragment
 import kr.co.lion.modigm.ui.chat.ChatFragment
 import kr.co.lion.modigm.ui.profile.ProfileFragment
+import kr.co.lion.modigm.ui.study.vm.BottomNaviViewModel
 import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.JoinType
 import kr.co.lion.modigm.util.ModigmApplication.Companion.prefs
@@ -21,34 +23,32 @@ class BottomNaviFragment : VBBaseFragment<FragmentBottomNaviBinding>(FragmentBot
         JoinType.getType(arguments?.getString("joinType")?:"")
     }
 
-    // 로그인 상태를 저장하는 변수
-    private var isSnackBarShown = false
+    private val viewModel: BottomNaviViewModel by viewModels()
 
     // --------------------------------- LC START ---------------------------------
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        // 이전 상태에서 isSnackBarShown 값 복원
-        isSnackBarShown = savedInstanceState?.getBoolean("isSnackBarShown") ?: false
-    }
-
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        // 현재 isSnackBarShown 상태 저장
-        outState.putBoolean("isSnackBarShown", isSnackBarShown)
+        // 현재 ViewModel의 isSnackBarShown 상태 저장
+        outState.putBoolean("isSnackBarShown", viewModel.isSnackBarShown.value ?: false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        // savedInstanceState에서 isSnackBarShown 값 복원
+        savedInstanceState?.getBoolean("isSnackBarShown")?.let {
+            viewModel.setSnackBarShown(it)
+        }
 
         initView()
         // 프리퍼런스 전체 확인 로그 (필터 입력: SharedPreferencesLog)
         prefs.logAllPreferences()
 
         // 다시 이 화면으로 돌아왔을 때 로그인 스낵바를 띄우지 않기
-        if (!isSnackBarShown) {
+        if (viewModel.isSnackBarShown.value == false) {
             showLoginSnackBar()
-            isSnackBarShown = true
+            viewModel.setSnackBarShown(true)
         }
 
         backButton()

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/vm/BottomNaviViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/vm/BottomNaviViewModel.kt
@@ -1,0 +1,14 @@
+package kr.co.lion.modigm.ui.study.vm
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class BottomNaviViewModel : ViewModel() {
+    private val _isSnackBarShown = MutableLiveData(false)
+    val isSnackBarShown: LiveData<Boolean> = _isSnackBarShown
+
+    fun setSnackBarShown(shown: Boolean) {
+        _isSnackBarShown.postValue(shown)
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#278 

## 📝작업 내용

1. 회원정보 수정의 전화번호 변경 리팩토링
2. 설정의 비밀번호 변경 리팩토링
3. 스낵바 내용 정렬 수정
4. 자동로그인 이메일 개선

### 스크린샷 (선택)

|전화번호 변경-이메일|전화번호 변경-소셜|
|:-----------------------:|:---------------------:|
|<video src="https://github.com/user-attachments/assets/93bef785-7e1d-4d93-953f-0087e9233b88" controls width="200">|<video src="https://github.com/user-attachments/assets/272715f7-d7a5-492a-8c39-7ab401497cfa" controls width="200">|


|비밀번호 변경-이메일|자동로그인 및 스낵바|
|:-----------------------:|:-----------------------:|
|<video src="https://github.com/user-attachments/assets/96ac1c6c-f1e6-40ac-b4eb-4fe335e9eb68" controls width="200">|<video src="https://github.com/user-attachments/assets/a1dbc7ac-2276-43f9-af7b-525422bd3e31" controls width="200">|




















## 💬리뷰 요구사항(선택)

현재 프로필에 설정메뉴가 다른 userIdx의 경우 나오지 않는 로직이라 녹화 시에만 값을 바꾸고 진행했습니다.

### 전화번호 변경
EditProfileFragment에서 전화번호 변경버튼을 눌렀을 때 넘어가는 페이지 분기 코드가 있습니다!

### 비밀번호 변경
SettingsFragment에서 비밀번호 변경 메뉴를 계정에 따라 뷰초기화 시 VISABLE/GONE 으로 처리했습니다!
그리고 로그아웃 할 때 로그인 프래그먼트의 자동로그인 함수가 프리퍼런스 값을 자꾸 불러와서 동작하고 있어서, 로그아웃 버튼 함수에 SharedPreferences 초기화 함수를 추가했습니다!

### 스낵바
말씀대로 아이콘과 메세지를 가운데로 모아봤습니다! 조금 더 깔끔해보입니다 ㅎㅎ 

### 이메일 자동로그인
이메일 자동 로그인 적용했습니다!  백버튼으로 나갔을 때와 완전히 종료될 때를 구분해야했는데, 현재는 앱 종료시 강제종료 함수를 쓰고있습니다.

제가 improve 머지받을 때 컨플릭트 난 부분에서 최대한 improve 우선적으로 적용하고, 제 코드는 더 추가되는 코드만 들어가도록 했는데, 이 PR이 머지되고 풀 받으실 때 오류가 난다면 말씀 꼭 부탁드려요! 