### PR TITLE
[#298] collectWhenStarted 함수 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/util/Extensions.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/Extensions.kt
@@ -20,13 +20,11 @@ import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import kr.co.lion.modigm.R
 import com.google.i18n.phonenumbers.PhoneNumberUtil
 import kr.co.lion.modigm.databinding.CustomSnackbarWithIconBinding
 import kr.co.lion.modigm.databinding.CustomSnackbarWithoutIconBinding
@@ -134,12 +132,9 @@ fun View.shake() {
 }
 
 // StateFlow값 collect하는 확장함수
-fun <T> LifecycleOwner.collectWhenStarted(flow: Flow<T>, firstTimeDelay: Long = 0L, action: suspend (value: T) -> Unit) {
+fun <T> LifecycleOwner.collectWhenStarted(flow: Flow<T>, action: suspend (value: T) -> Unit) {
     lifecycleScope.launch {
-        delay(firstTimeDelay)
-        lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-            flow.collect(action)
-        }
+        flow.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collect(action)
     }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #298

## 📝작업 내용

> flow collect해주는 확장 함수가 기존에 repeatOnLifecycle로 수행하는 코드였는데, 구글에서 권장하는 flowWithLifecycle로 변경했습니다.
collectWhenStarted 함수의 첫 번째 인자가 collect할 flow값이고, 두 번째 인자가 flow값 변경 시 수행할 람다입니다
변경 후 문제없이 실행되는 부분 확인했습니다
혹시라도 코드가 잘못되었거나 수정할 부분이 있다면 말씀 부탁드립니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
