### PR TITLE
[feature #303] 상세화면 좋아요 적용

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/db/detail/SqlRemoteDetailDao.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/detail/SqlRemoteDetailDao.kt
@@ -98,12 +98,12 @@ class SqlRemoteDetailDao {
     }
 
     // studyState 값을 업데이트하는 메소드 추가
-    suspend fun updateStudyState(studyIdx: Int, newState: Int): Int = withContext(Dispatchers.IO) {
+    suspend fun updateStudyState(studyIdx: Int, newState: Boolean): Int = withContext(Dispatchers.IO) {
         try {
             HikariCPDataSource.getConnection().use { connection ->
                 val query = "UPDATE tb_study SET studyState = ? WHERE studyIdx = ?"
                 connection.prepareStatement(query).use { statement ->
-                    statement.setInt(1, newState)
+                    statement.setInt(1, if (newState) 1 else 0)
                     statement.setInt(2, studyIdx)
                     return@withContext statement.executeUpdate()
                 }

--- a/app/src/main/java/kr/co/lion/modigm/db/detail/SqlRemoteDetailDao.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/detail/SqlRemoteDetailDao.kt
@@ -307,4 +307,20 @@ class SqlRemoteDetailDao {
         }
     }
 
+    suspend fun updateStudyCanApplyField(studyIdx: Int, newState: String): Int = withContext(Dispatchers.IO) {
+        try {
+            HikariCPDataSource.getConnection().use { connection ->
+                val query = "UPDATE tb_study SET studyCanApply = ? WHERE studyIdx = ?"
+                connection.prepareStatement(query).use { statement ->
+                    statement.setString(1, newState)
+                    statement.setInt(2, studyIdx)
+                    return@withContext statement.executeUpdate()
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error updating studyCanApply field", e)
+            return@withContext 0
+        }
+    }
+
 }

--- a/app/src/main/java/kr/co/lion/modigm/db/detail/SqlRemoteDetailDataSource.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/detail/SqlRemoteDetailDataSource.kt
@@ -149,4 +149,13 @@ class SqlRemoteDetailDataSource {
         return studyDao.removeUserFromStudyRequest(studyIdx, userIdx)
     }
 
+    suspend fun updateStudyCanApplyField(studyIdx: Int, newState: String): Boolean {
+        return try {
+            studyDao.updateStudyCanApplyField(studyIdx, newState) > 0
+        } catch (e: Exception) {
+            Log.e("RemoteDetailDataSource Error", "Error updateStudyCanApplyField: ${e.message}")
+            false
+        }
+    }
+
 }

--- a/app/src/main/java/kr/co/lion/modigm/db/detail/SqlRemoteDetailDataSource.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/detail/SqlRemoteDetailDataSource.kt
@@ -91,7 +91,7 @@ class SqlRemoteDetailDataSource {
     }
 
     // studyState 값을 업데이트하는 메소드 추가
-    suspend fun updateStudyState(studyIdx: Int, newState: Int): Boolean {
+    suspend fun updateStudyState(studyIdx: Int, newState: Boolean): Boolean {
         return try {
             studyDao.updateStudyState(studyIdx, newState) > 0
         } catch (e: Exception) {

--- a/app/src/main/java/kr/co/lion/modigm/repository/SqlDetailRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/SqlDetailRepository.kt
@@ -42,7 +42,7 @@ class SqlDetailRepository {
     }.flowOn(Dispatchers.IO)
 
     // studyState 값을 업데이트하는 메소드 추가
-    suspend fun updateStudyState(studyIdx: Int, newState: Int): Boolean {
+    suspend fun updateStudyState(studyIdx: Int, newState: Boolean): Boolean {
         return sqlRemoteDetailDataSource.updateStudyState(studyIdx, newState)
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/repository/SqlDetailRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/SqlDetailRepository.kt
@@ -85,4 +85,8 @@ class SqlDetailRepository {
     suspend fun removeUserFromStudyRequest(studyIdx: Int, userIdx: Int): Boolean {
         return sqlRemoteDetailDataSource.removeUserFromStudyRequest(studyIdx, userIdx)
     }
+
+    suspend fun updateStudyCanApplyField(studyIdx: Int, newState: String): Boolean {
+        return sqlRemoteDetailDataSource.updateStudyCanApplyField(studyIdx, newState)
+    }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -99,6 +99,9 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
 
         observeViewModel()
 
+        // 초기 좋아요 상태 확인
+        viewModel.checkIfLiked(userIdx, studyIdx)
+
     }
 
     fun fetchDataAndUpdateUI() {
@@ -113,19 +116,6 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
             awaitAll(dataDeferred, membersDeferred, techDeferred, imageDeferred)
         }
 
-
-        // 좋아요 토글 및 상태
-//        lifecycleScope.launch {
-//            viewModel.isLiked.collect { isLiked ->
-//                if (isLiked) {
-//                    binding.buttonDetailLike.setImageResource(R.drawable.icon_favorite_full_24px)
-//                    binding.buttonDetailLike.setColorFilter(Color.parseColor("#D73333"))
-//                } else {
-//                    binding.buttonDetailLike.setImageResource(R.drawable.icon_favorite_24px)
-//                    binding.buttonDetailLike.setColorFilter(ContextCompat.getColor(requireContext(), R.color.pointColor))
-//                }
-//            }
-//        }
     }
     private suspend fun loadImage() {
         viewModel.studyPic.collect { imageUrl ->
@@ -212,6 +202,22 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
             }
         }
 
+        lifecycleScope.launch {
+            viewModel.isLiked.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collect { isLiked ->
+                updateLikeButton(isLiked)
+            }
+        }
+
+    }
+
+    private fun updateLikeButton(isLiked: Boolean) {
+        if (isLiked) {
+            binding.buttonDetailLike.setImageResource(R.drawable.icon_favorite_full_24px)
+            binding.buttonDetailLike.setColorFilter(Color.parseColor("#D73333"))
+        } else {
+            binding.buttonDetailLike.setImageResource(R.drawable.icon_favorite_24px)
+            binding.buttonDetailLike.setColorFilter(ContextCompat.getColor(requireContext(), R.color.pointColor))
+        }
     }
 
     private fun loadUserImage(imageUrl: String?) {
@@ -306,9 +312,6 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
             // 스터디 인원(총인원)
             textViewDetailMemberTotal.text = data.studyMaxMember.toString()
 
-            // 스터디 인원 (참가 인원)
-//            textViewDetailMember.text = data.studyUidList.size.toString()
-
 
             // 스터디 방식(온라인 / 오프라인 / 온오프 -> 온라인 제외하고는 주소 이름으로 사용)
             val studyOnOffline = when (data.studyOnOffline) {
@@ -338,7 +341,6 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
 
             // 모집 상태에 따라 textViewDetailState의 텍스트 설정
             if (data.studyCanApply == "모집중") {
-//                Log.d("DetailFragment", "User Profile Pic URL: ${data.studyCanApply}")
                 // 모집중 상태
                 textViewDetailState.text = "모집중"
                 setupStatePopup()
@@ -414,7 +416,7 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
     // 좋아요 버튼 설정
     fun setupLikeButtonListener() {
         binding.buttonDetailLike.setOnClickListener {
-//            viewModel.toggleLike(uid, studyIdx)
+            viewModel.toggleFavoriteStatus(userIdx, studyIdx)
         }
     }
 
@@ -581,11 +583,6 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
                     0
                 )
             }
-        }
-
-        binding.buttonDetailApply.setOnClickListener {
-            Log.d("DetailFragment", "채팅방 이동1")
-//            moveChatRoom()
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -527,7 +527,7 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
             .create()
 
         dialogView.findViewById<TextView>(R.id.btnYes).setOnClickListener {
-            viewModel.updateStudyState(studyIdx, 2)  // studyState 값을 2로 업데이트
+            viewModel.updateStudyState(studyIdx, false)  // studyState 값을 false로 업데이트
             // 예 버튼 로직
             Log.d("Dialog", "확인을 선택했습니다.")
             dialog.dismiss()

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.transition.TransitionManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.DecodeFormat
 import com.bumptech.glide.load.engine.DiskCacheStrategy
@@ -548,6 +549,8 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
 
         if (currentStudyData?.userIdx == userIdx) {
             setupOwnerView(textViewState)
+            // 버튼 클릭 비활성화
+            binding.buttonDetailApply.isEnabled = false
         } else {
             setupNonOwnerView(textViewState)
         }
@@ -562,6 +565,8 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
         )
 
         textViewState.isEnabled = true
+        binding.buttonDetailApply.isEnabled = false
+        binding.buttonDetailApply.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.pointColor))
 
         textViewState.setOnClickListener { view ->
             Log.d("DetailFragment", "TextViewState clicked for owner")
@@ -585,7 +590,6 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
             }
         }
     }
-
     private fun setupNonOwnerView(textViewState: TextView) {
         textViewState.isEnabled = false
         textViewState.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
@@ -668,13 +672,16 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
         // 팝업 메뉴 아이템의 클릭 리스너 설정
         popupView.findViewById<TextView>(R.id.textViewDetailState1).setOnClickListener {
             binding.textViewDetailState.text = (it as TextView).text
-//            viewModel.updateStudyCanApplyByStudyIdx(studyIdx, true)  // 모집중 상태로 업데이트
             popupWindow.dismiss()
+            // "모집중" 상태로 업데이트
+            viewModel.updateStudyCanApplyInBackground(studyIdx, true)
         }
         popupView.findViewById<TextView>(R.id.textViewDetailState2).setOnClickListener {
             binding.textViewDetailState.text = (it as TextView).text
-//            viewModel.updateStudyCanApplyByStudyIdx(studyIdx, false)  // 모집중 상태로 업데이트
             popupWindow.dismiss()
+            // "모집완료" 상태로 업데이트
+            viewModel.updateStudyCanApplyInBackground(studyIdx, false)
         }
     }
+
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/PlaceBottomSheetFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/PlaceBottomSheetFragment.kt
@@ -37,13 +37,6 @@ class PlaceBottomSheetFragment : VBBaseBottomSheetFragment<FragmentPlaceBottomSh
 
     private var placeSelectedListener: OnPlaceSelectedListener? = null
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/SkillBottomSheetFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/SkillBottomSheetFragment.kt
@@ -41,8 +41,6 @@ class SkillBottomSheetFragment : VBBaseBottomSheetFragment<FragmentSkillBottomSh
         ScrollViewSkillSelectVisibility()
         binding.imageViewSkillBottomSheetClose.setOnClickListener { dismiss() }
 
-//        // 초기 선택된 스킬 설정
-//        setSelectedSkills(initialSkills)
         // 초기 선택된 스킬을 바인딩이 완료된 후에 처리
         applySelectedSkills()
     }
@@ -76,28 +74,6 @@ class SkillBottomSheetFragment : VBBaseBottomSheetFragment<FragmentSkillBottomSh
     fun setOnSkillSelectedListener(listener: OnSkillSelectedListener) {
         skillSelectedListener = listener
     }
-
-//    fun setSelectedSkills(skills: List<Skill>) {
-//        initialSkills = skills
-//        if (::binding.isInitialized) {
-//            selectedSkills.clear()
-//            selectedSkills.addAll(skills)
-//            updateSelectedChipsUI()
-//
-//            // 선택된 스킬이 있는 카테고리의 칩을 선택하고 서브 카테고리 칩들을 모두 선택
-//            skills.forEach { skill ->
-//                val category = skill.category
-//                if (category != null) {
-//                    // 해당 카테고리 칩 선택
-//                    updateCategoryChipState(skill, true)
-//                    // 해당 카테고리의 서브 카테고리 칩들을 생성 및 선택
-//                    displaySubCategories(category)
-//                    // 서브 카테고리에서 해당 스킬 칩 선택
-//                    selectSubCategoryChip(skill)
-//                }
-//            }
-//        }
-//    }
 
     fun setSelectedSkills(skills: List<Skill>) {
         initialSkills = skills
@@ -282,13 +258,6 @@ class SkillBottomSheetFragment : VBBaseBottomSheetFragment<FragmentSkillBottomSh
     }
 
     fun updateCategoryChipState(skill: Skill, isSelected: Boolean) {
-//        binding.chipGroupSkill.children.forEach {
-//            val chip = it as Chip
-//            if (chip.text.toString() == getCategoryName(skill.category ?: Skill.Category.OTHER)) {
-//                chip.isChecked = isSelected
-//                updateChipStyle(chip, isSelected)
-//            }
-//        }
         binding.chipGroupSkill.children.forEach { view ->
             val chip = view as Chip
             if (chip.text.toString() == getCategoryName(skill.category ?: Skill.Category.OTHER)) {
@@ -308,16 +277,6 @@ class SkillBottomSheetFragment : VBBaseBottomSheetFragment<FragmentSkillBottomSh
             dismiss()
         }
     }
-
-//    fun updateChipStyle(chip: Chip, isSelected: Boolean) {
-//        if (isSelected) {
-//            chip.setChipBackgroundColorResource(R.color.pointColor)
-//            chip.setTextColor(resources.getColor(R.color.white, null))
-//        } else {
-//            chip.setChipBackgroundColorResource(R.color.white)
-//            chip.setTextColor(resources.getColor(R.color.black, null))
-//        }
-//    }
 
     fun updateChipStyle(chip: Chip, isSelected: Boolean) {
         if (isSelected) {

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/SqlDetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/SqlDetailViewModel.kt
@@ -13,10 +13,12 @@ import kotlinx.coroutines.launch
 import kr.co.lion.modigm.model.SqlStudyData
 import kr.co.lion.modigm.model.SqlUserData
 import kr.co.lion.modigm.repository.SqlDetailRepository
+import kr.co.lion.modigm.repository.StudyListRepository
 
 class SqlDetailViewModel: ViewModel() {
 
     private val sqlDetailRepository = SqlDetailRepository()
+    private val studyListRepository = StudyListRepository()
 
     private val _studyData = MutableStateFlow<SqlStudyData?>(null)
     val studyData: StateFlow<SqlStudyData?> = _studyData
@@ -59,6 +61,9 @@ class SqlDetailViewModel: ViewModel() {
 
     private val _removeUserFromApplyResult = MutableSharedFlow<Boolean>()
     val removeUserFromApplyResult: SharedFlow<Boolean> = _removeUserFromApplyResult
+
+    private val _isLiked = MutableStateFlow(false)
+    val isLiked: StateFlow<Boolean> = _isLiked
 
     fun clearData() {
         _studyData.value = null
@@ -139,20 +144,6 @@ class SqlDetailViewModel: ViewModel() {
         }
     }
 
-    // 특정 userIdx에 대한 사용자 데이터를 가져오는 메소드
-//    fun getUserById(userIdx: Int) {
-//        viewModelScope.launch {
-//            try {
-//                sqlDetailRepository.getUserById(userIdx).collect { user ->
-//                    _userData.value = user
-//                    Log.d("DetailViewModel", "Fetched user data: $user")
-//                }
-//            } catch (throwable: Throwable) {
-//                Log.e("DetailViewModel", "Error fetching user data", throwable)
-//            }
-//        }
-//    }
-
     fun getUserById(userIdx: Int) {
         viewModelScope.launch(Dispatchers.IO) {
             _userData.value = null  // 데이터 로드 전에 null로 초기화
@@ -170,8 +161,6 @@ class SqlDetailViewModel: ViewModel() {
             }
         }
     }
-
-
 
     fun getTechIdxByStudyIdx(studyIdx: Int) {
         viewModelScope.launch {
@@ -238,8 +227,6 @@ class SqlDetailViewModel: ViewModel() {
         viewModelScope.launch {
             val result = sqlDetailRepository.acceptUser(studyIdx, userIdx)
             _acceptUserResult.emit(result)
-//            // 신청자 리스트를 다시 로드
-//            fetchStudyRequestMembers(studyIdx)
 
             if (result) {
                 // 신청자 리스트를 다시 로드
@@ -276,5 +263,28 @@ class SqlDetailViewModel: ViewModel() {
         }
     }
 
+    // 좋아요 상태 확인 메소드
+    fun checkIfLiked(userIdx: Int, studyIdx: Int) {
+        viewModelScope.launch {
+            val result = studyListRepository.getFavoriteStudyData(userIdx).getOrNull()?.any { it.first.studyIdx == studyIdx } ?: false
+            _isLiked.value = result
+        }
+    }
 
+    // 좋아요 상태 토글 메소드
+    fun toggleFavoriteStatus(userIdx: Int, studyIdx: Int) {
+        viewModelScope.launch {
+            if (_isLiked.value) {
+                val result = studyListRepository.removeFavorite(userIdx, studyIdx).getOrNull()
+                if (result == true) {
+                    _isLiked.value = false
+                }
+            } else {
+                val result = studyListRepository.addFavorite(userIdx, studyIdx).getOrNull()
+                if (result == true) {
+                    _isLiked.value = true
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/SqlDetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/SqlDetailViewModel.kt
@@ -171,7 +171,7 @@ class SqlDetailViewModel: ViewModel() {
     }
 
     // studyState 값을 업데이트하는 메소드 추가
-    fun updateStudyState(studyIdx: Int, newState: Int) {
+    fun updateStudyState(studyIdx: Int, newState: Boolean) {
         viewModelScope.launch {
             val result = sqlDetailRepository.updateStudyState(studyIdx, newState)
             _updateResult.emit(result)

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/SqlDetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/SqlDetailViewModel.kt
@@ -287,4 +287,24 @@ class SqlDetailViewModel: ViewModel() {
             }
         }
     }
+
+    // studyCanApply 값을 업데이트하는 메소드
+    fun updateStudyCanApplyInBackground(studyIdx: Int, canApply: Boolean) {
+        viewModelScope.launch {
+            try {
+                val newState = if (canApply) "모집중" else "모집완료"
+                val result = sqlDetailRepository.updateStudyCanApplyField(studyIdx, newState)
+                if (result) {
+                    // DB 업데이트 성공 시, 별도의 UI 갱신을 하지 않음
+                    Log.d("SqlDetailViewModel", "Study state updated successfully.")
+                } else {
+                    // 실패 시, 사용자에게 오류를 알리거나, 로그를 남기거나, 상태 복구 등의 처리
+                    Log.e("SqlDetailViewModel", "Failed to update study state.")
+                }
+            } catch (e: Exception) {
+                Log.e("SqlDetailViewModel", "Error updating studyCanApply", e)
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #303 

## 📝작업 내용

1. 상세화면 좋아요 작업

2. 상세화면에서 모집 상태 변경
변경 시 바로 데이터를 받아와서 UI를 갱신 시키면 일부 text들이 깜박 거리며 로딩되는 문제가 있어 DB 업데이트 성공 시, UI 갱신을 하지 않고 자체적으로 UI업데이트를 진행해 해결했습니다

3. 기존에는 채팅방으로 이동을 시켜야 해서 글 작성자도 본인의 스터디 상세글에서 신청하기버튼( 구 채팅방 이동하기 버튼)이 클릭이 되도록 했었지만 채팅기능을 제외하면 클릭기능이 필요 없을것 같아 막아뒀습니다.

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 기존 기능과 달라진 부분이나 추가된 부분이 크게 없어서 스크린 샷은 생략했습니다.
> 데이터베이스를 mysql로 변경하면서 달라진 부분들을 수정해서 재 구현 한거라 따로 스크린샷이나 영상은 안찍었지만 만약 보고싶으신 부분이 있으면 comment남겨주세요 수정해두겠습니다.
