### PR TITLE
[feature #310] 스터디 상세화면 이미지 상세보기 기능

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/db/detail/RemoteDetailDao.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/detail/RemoteDetailDao.kt
@@ -1,18 +1,14 @@
 package kr.co.lion.modigm.db.detail
 
 import android.util.Log
-import com.zaxxer.hikari.HikariConfig
-import com.zaxxer.hikari.HikariDataSource
 import kotlinx.coroutines.*
-import kr.co.lion.modigm.BuildConfig
 import kr.co.lion.modigm.db.HikariCPDataSource
 import kr.co.lion.modigm.model.SqlStudyData
 import kr.co.lion.modigm.model.SqlUserData
-import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 
-class SqlRemoteDetailDao {
+class RemoteDetailDao {
     private val TAG = "SqlRemoteDetailDao"
 
     // 쿼리를 실행하고 결과를 처리하는 공통 메소드

--- a/app/src/main/java/kr/co/lion/modigm/db/detail/RemoteDetailDataSource.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/detail/RemoteDetailDataSource.kt
@@ -4,9 +4,9 @@ import android.util.Log
 import kr.co.lion.modigm.model.SqlStudyData
 import kr.co.lion.modigm.model.SqlUserData
 
-class SqlRemoteDetailDataSource {
+class RemoteDetailDataSource {
     private val TAG = "SqlRemoteDetailDataSource"
-    private val studyDao = SqlRemoteDetailDao()
+    private val studyDao = RemoteDetailDao()
 
     // 특정 studyIdx에 해당하는 스터디 데이터를 가져오는 메소드
     suspend fun getStudyById(studyIdx: Int): SqlStudyData? {

--- a/app/src/main/java/kr/co/lion/modigm/repository/DetailRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/DetailRepository.kt
@@ -4,89 +4,89 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kr.co.lion.modigm.db.detail.SqlRemoteDetailDataSource
+import kr.co.lion.modigm.db.detail.RemoteDetailDataSource
 import kr.co.lion.modigm.model.SqlStudyData
 import kr.co.lion.modigm.model.SqlUserData
 
-class SqlDetailRepository {
-    private val sqlRemoteDetailDataSource = SqlRemoteDetailDataSource()
+class DetailRepository {
+    private val remoteDetailDataSource = RemoteDetailDataSource()
 
     // 특정 studyIdx에 해당하는 스터디 데이터를 가져오는 메소드
     fun getStudyById(studyIdx: Int): Flow<SqlStudyData?> = flow {
-        emit(sqlRemoteDetailDataSource.getStudyById(studyIdx))
+        emit(remoteDetailDataSource.getStudyById(studyIdx))
     }.flowOn(Dispatchers.IO)
 
     // 특정 studyIdx에 해당하는 스터디 멤버 수를 가져오는 메소드
     fun countMembersByStudyIdx(studyIdx: Int): Flow<Int> = flow {
-        emit(sqlRemoteDetailDataSource.countMembersByStudyIdx(studyIdx))
+        emit(remoteDetailDataSource.countMembersByStudyIdx(studyIdx))
     }.flowOn(Dispatchers.IO)
 
     // 특정 studyIdx에 해당하는 스터디 이미지를 가져오는 메소드
     fun getStudyPicByStudyIdx(studyIdx: Int): Flow<String?> = flow {
-        emit(sqlRemoteDetailDataSource.getStudyPicByStudyIdx(studyIdx))
+        emit(remoteDetailDataSource.getStudyPicByStudyIdx(studyIdx))
     }.flowOn(Dispatchers.IO)
 
     // 특정 studyIdx에 해당하는 userIdx 리스트를 가져오는 메소드
     suspend fun getUserIdsByStudyIdx(studyIdx: Int): List<Int> {
-        return sqlRemoteDetailDataSource.getUserIdsByStudyIdx(studyIdx)
+        return remoteDetailDataSource.getUserIdsByStudyIdx(studyIdx)
     }
 
     // 특정 userIdx에 해당하는 사용자 데이터를 가져오는 메소드
     fun getUserById(userIdx: Int): Flow<SqlUserData?> = flow {
-        emit(sqlRemoteDetailDataSource.getUserById(userIdx))
+        emit(remoteDetailDataSource.getUserById(userIdx))
     }
 
     fun getTechIdxByStudyIdx(studyIdx: Int): Flow<List<Int>> = flow {
-        val techList = sqlRemoteDetailDataSource.getTechIdxByStudyIdx(studyIdx)
+        val techList = remoteDetailDataSource.getTechIdxByStudyIdx(studyIdx)
         emit(techList)
     }.flowOn(Dispatchers.IO)
 
     // studyState 값을 업데이트하는 메소드 추가
     suspend fun updateStudyState(studyIdx: Int, newState: Boolean): Boolean {
-        return sqlRemoteDetailDataSource.updateStudyState(studyIdx, newState)
+        return remoteDetailDataSource.updateStudyState(studyIdx, newState)
     }
 
     // 스터디 데이터를 업데이트하는 메소드
     suspend fun updateStudy(studyData: SqlStudyData): Boolean {
-        return sqlRemoteDetailDataSource.updateStudy(studyData)
+        return remoteDetailDataSource.updateStudy(studyData)
     }
 
     // 스킬 데이터를 삽입하는 메서드 추가
     suspend fun insertSkills(studyIdx: Int, skills: List<Int>) {
-        sqlRemoteDetailDataSource.insertSkills(studyIdx, skills)
+        remoteDetailDataSource.insertSkills(studyIdx, skills)
     }
 
     // 특정 studyIdx와 userIdx에 해당하는 사용자를 스터디에서 삭제하는 메소드
     suspend fun removeUserFromStudy(studyIdx: Int, userIdx: Int): Boolean {
-        return sqlRemoteDetailDataSource.removeUserFromStudy(studyIdx, userIdx)
+        return remoteDetailDataSource.removeUserFromStudy(studyIdx, userIdx)
     }
 
     suspend fun addUserToStudy(studyIdx: Int, userIdx: Int): Boolean {
-        return sqlRemoteDetailDataSource.addUserToStudy(studyIdx, userIdx)
+        return remoteDetailDataSource.addUserToStudy(studyIdx, userIdx)
     }
 
     suspend fun addUserToStudyRequest(studyIdx: Int, userIdx: Int): Boolean {
-        return sqlRemoteDetailDataSource.addUserToStudyRequest(studyIdx, userIdx)
+        return remoteDetailDataSource.addUserToStudyRequest(studyIdx, userIdx)
     }
 
     suspend fun getStudyRequestMembers(studyIdx: Int): List<SqlUserData> {
-        return sqlRemoteDetailDataSource.getStudyRequestMembers(studyIdx)
+        return remoteDetailDataSource.getStudyRequestMembers(studyIdx)
     }
 
     suspend fun acceptUser(studyIdx: Int, userIdx: Int): Boolean {
-        val added = sqlRemoteDetailDataSource.addUserToStudyMember(studyIdx, userIdx)
+        val added = remoteDetailDataSource.addUserToStudyMember(studyIdx, userIdx)
         if (added) {
-            return sqlRemoteDetailDataSource.removeUserFromStudyRequest(studyIdx, userIdx)
+            return remoteDetailDataSource.removeUserFromStudyRequest(studyIdx, userIdx)
         }
         return false
     }
 
     // 특정 사용자를 tb_study_request에서 삭제하는 메소드
     suspend fun removeUserFromStudyRequest(studyIdx: Int, userIdx: Int): Boolean {
-        return sqlRemoteDetailDataSource.removeUserFromStudyRequest(studyIdx, userIdx)
+        return remoteDetailDataSource.removeUserFromStudyRequest(studyIdx, userIdx)
     }
 
     suspend fun updateStudyCanApplyField(studyIdx: Int, newState: String): Boolean {
-        return sqlRemoteDetailDataSource.updateStudyCanApplyField(studyIdx, newState)
+        return remoteDetailDataSource.updateStudyCanApplyField(studyIdx, newState)
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailApplyMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailApplyMemberFragment.kt
@@ -2,30 +2,25 @@ package kr.co.lion.modigm.ui.detail
 
 import android.os.Bundle
 import android.util.Log
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.launch
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentDetailApplyMemberBinding
-import kr.co.lion.modigm.databinding.FragmentDetailBinding
 import kr.co.lion.modigm.ui.VBBaseFragment
 import kr.co.lion.modigm.ui.detail.adapter.DetailApplyMembersAdapter
-import kr.co.lion.modigm.ui.detail.vm.SqlDetailViewModel
+import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
 import kr.co.lion.modigm.ui.profile.ProfileFragment
 import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.ModigmApplication
 
 class DetailApplyMemberFragment : VBBaseFragment<FragmentDetailApplyMemberBinding>(FragmentDetailApplyMemberBinding::inflate) {
 
-    private val viewModel: SqlDetailViewModel by activityViewModels()
+    private val viewModel: DetailViewModel by activityViewModels()
     private lateinit var adapter: DetailApplyMembersAdapter
 
     // 현재 선택된 스터디 idx 번호를 담을 변수(임시)

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailEditFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailEditFragment.kt
@@ -16,7 +16,6 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.util.Log
 import android.util.TypedValue
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -43,7 +42,7 @@ import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentDetailEditBinding
 import kr.co.lion.modigm.model.SqlStudyData
 import kr.co.lion.modigm.ui.VBBaseFragment
-import kr.co.lion.modigm.ui.detail.vm.SqlDetailViewModel
+import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
 import kr.co.lion.modigm.util.Skill
 import java.io.File
 
@@ -52,7 +51,7 @@ class DetailEditFragment : VBBaseFragment<FragmentDetailEditBinding>(FragmentDet
 
 //    lateinit var fragmentDetailEditBinding: FragmentDetailEditBinding
 
-    private val viewModel: SqlDetailViewModel by activityViewModels()
+    private val viewModel: DetailViewModel by activityViewModels()
 
 //    private lateinit var auth: FirebaseAuth
 //    private lateinit var uid: String

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -1,13 +1,11 @@
 package kr.co.lion.modigm.ui.detail
 
 import android.content.Context
-import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
 import android.util.TypedValue
 import android.view.Gravity
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -21,22 +19,15 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
-import androidx.transition.TransitionManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.DecodeFormat
 import com.bumptech.glide.load.engine.DiskCacheStrategy
-import com.bumptech.glide.load.resource.bitmap.BitmapTransitionOptions
-import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
-import com.bumptech.glide.load.resource.bitmap.Downsampler
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.bumptech.glide.request.RequestOptions
-import com.bumptech.glide.request.transition.DrawableCrossFadeFactory
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.chip.Chip
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
-import com.google.firebase.firestore.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -44,11 +35,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentDetailBinding
-import kr.co.lion.modigm.databinding.FragmentDetailEditBinding
 import kr.co.lion.modigm.model.SqlStudyData
 import kr.co.lion.modigm.model.SqlUserData
 import kr.co.lion.modigm.ui.VBBaseFragment
-import kr.co.lion.modigm.ui.detail.vm.SqlDetailViewModel
+import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
 import kr.co.lion.modigm.ui.profile.ProfileFragment
 import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.ModigmApplication
@@ -57,7 +47,7 @@ import kr.co.lion.modigm.util.Skill
 class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBinding::inflate) {
 
     // 뷰 모델
-    private val viewModel: SqlDetailViewModel by activityViewModels()
+    private val viewModel: DetailViewModel by activityViewModels()
 
     private var isPopupShown = false
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.PopupWindow
 import android.widget.TextView
@@ -103,7 +104,45 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
         // 초기 좋아요 상태 확인
         viewModel.checkIfLiked(userIdx, studyIdx)
 
+        // 이미지 클릭 리스너 설정
+        binding.imageViewDetailCover.setOnClickListener {
+            showImageZoomDialog()
+        }
+
     }
+
+    // 확대된 이미지를 보여주는 Dialog
+    private fun showImageZoomDialog() {
+        // Dialog 생성
+        val dialogView = LayoutInflater.from(requireContext()).inflate(R.layout.fragment_detail_image_zoom, null)
+        val dialog = android.app.AlertDialog.Builder(requireContext()).create()
+        dialog.setView(dialogView)
+
+        // ImageView 참조
+        val imageViewZoomed = dialogView.findViewById<ImageView>(R.id.imageViewZoomed)
+        val imageViewClose = dialogView.findViewById<ImageView>(R.id.imageViewClose)
+
+        // 이미지를 Glide로 로드하여 ImageView에 설정
+        currentStudyData?.let { data ->
+            Glide.with(this)
+                .load(data.studyPic) // 확대할 이미지 URL
+                .apply(RequestOptions()
+                    .placeholder(R.drawable.image_loading_gray)
+                    .error(R.drawable.icon_error_24px)
+                    .diskCacheStrategy(DiskCacheStrategy.ALL)
+                    .override(1600, 1200)) // 이미지 크기 조정 (선택 사항)
+                .into(imageViewZoomed)
+        }
+
+        // "X" 버튼 클릭 시 Dialog 닫기
+        imageViewClose.setOnClickListener {
+            dialog.dismiss()
+        }
+
+        // Dialog를 보여줍니다.
+        dialog.show()
+    }
+
 
     fun fetchDataAndUpdateUI() {
         lifecycleScope.launch {

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailJoinMemberFragment.kt
@@ -13,7 +13,7 @@ import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentDetailJoinMemberBinding
 import kr.co.lion.modigm.ui.VBBaseFragment
 import kr.co.lion.modigm.ui.detail.adapter.DetailJoinMembersAdapter
-import kr.co.lion.modigm.ui.detail.vm.SqlDetailViewModel
+import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
 import kr.co.lion.modigm.ui.profile.ProfileFragment
 import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.ModigmApplication
@@ -21,7 +21,7 @@ import kr.co.lion.modigm.util.ModigmApplication
 //참여중인 멤버
 class DetailJoinMemberFragment : VBBaseFragment<FragmentDetailJoinMemberBinding>(FragmentDetailJoinMemberBinding::inflate) {
 
-    private val viewModel: SqlDetailViewModel by activityViewModels()
+    private val viewModel: DetailViewModel by activityViewModels()
     private lateinit var adapter: DetailJoinMembersAdapter
 
     // 현재 선택된 스터디 idx 번호를 담을 변수(임시)

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailApplyMembersAdapter.kt
@@ -15,10 +15,10 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.RowDetailApplyMemberBinding
 import kr.co.lion.modigm.model.SqlUserData
-import kr.co.lion.modigm.ui.detail.vm.SqlDetailViewModel
+import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
 
 class DetailApplyMembersAdapter(
-    private val viewModel: SqlDetailViewModel,
+    private val viewModel: DetailViewModel,
     private val currentUserId: Int,
     private val studyIdx: Int,
     private val onItemClicked: (SqlUserData) -> Unit

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/adapter/DetailJoinMembersAdapter.kt
@@ -15,11 +15,11 @@ import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.CustomDialogBinding
 import kr.co.lion.modigm.databinding.RowDetailJoinMemberBinding
 import kr.co.lion.modigm.model.SqlUserData
-import kr.co.lion.modigm.ui.detail.vm.SqlDetailViewModel
+import kr.co.lion.modigm.ui.detail.vm.DetailViewModel
 import kr.co.lion.modigm.util.ModigmApplication
 
 class DetailJoinMembersAdapter(
-    private val viewModel: SqlDetailViewModel,
+    private val viewModel: DetailViewModel,
     private var currentUserId: Int,
     private val studyIdx: Int,
     private val onItemClicked: (SqlUserData) -> Unit

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
@@ -3,7 +3,6 @@ package kr.co.lion.modigm.ui.detail.vm
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.bumptech.glide.Glide
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,12 +11,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kr.co.lion.modigm.model.SqlStudyData
 import kr.co.lion.modigm.model.SqlUserData
-import kr.co.lion.modigm.repository.SqlDetailRepository
+import kr.co.lion.modigm.repository.DetailRepository
 import kr.co.lion.modigm.repository.StudyRepository
 
-class SqlDetailViewModel: ViewModel() {
+class DetailViewModel: ViewModel() {
 
-    private val sqlDetailRepository = SqlDetailRepository()
+    private val detailRepository = DetailRepository()
     private val studyRepository = StudyRepository()
 
     private val _studyData = MutableStateFlow<SqlStudyData?>(null)
@@ -78,7 +77,7 @@ class SqlDetailViewModel: ViewModel() {
     fun getStudy(studyIdx: Int) {
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                sqlDetailRepository.getStudyById(studyIdx).collect { data ->
+                detailRepository.getStudyById(studyIdx).collect { data ->
                     _studyData.value = data
                     data?.let { getStudyPic(it.studyIdx) } // 데이터 가져온 후 이미지 로드
                 }
@@ -92,7 +91,7 @@ class SqlDetailViewModel: ViewModel() {
     fun countMembersByStudyIdx(studyIdx: Int) {
         viewModelScope.launch {
             try {
-                sqlDetailRepository.countMembersByStudyIdx(studyIdx).collect { count ->
+                detailRepository.countMembersByStudyIdx(studyIdx).collect { count ->
                     _memberCount.value = count
                 }
             } catch (throwable: Throwable) {
@@ -104,7 +103,7 @@ class SqlDetailViewModel: ViewModel() {
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 // studyIdx에 해당하는 userIdx 리스트 가져오기
-                val userIds = sqlDetailRepository.getUserIdsByStudyIdx(studyIdx)
+                val userIds = detailRepository.getUserIdsByStudyIdx(studyIdx)
                 Log.d("SqlDetailViewModel", "Fetched user IDs: $userIds")
 
                 if (userIds.isEmpty()) {
@@ -116,7 +115,7 @@ class SqlDetailViewModel: ViewModel() {
                 val users = mutableListOf<SqlUserData>()
 
                 userIds.forEach { userIdx ->
-                    sqlDetailRepository.getUserById(userIdx).collect { user ->
+                    detailRepository.getUserById(userIdx).collect { user ->
                         user?.let {
                             users.add(it)
                             Log.d("SqlDetailViewModel", "Fetched user data: $user")
@@ -138,7 +137,7 @@ class SqlDetailViewModel: ViewModel() {
     // 특정 studyIdx에 대한 스터디 이미지를 가져오는 메소드
     fun getStudyPic(studyIdx: Int) {
         viewModelScope.launch(Dispatchers.IO) {
-            sqlDetailRepository.getStudyPicByStudyIdx(studyIdx).collect { pic ->
+            detailRepository.getStudyPicByStudyIdx(studyIdx).collect { pic ->
                 _studyPic.value = pic
             }
         }
@@ -148,7 +147,7 @@ class SqlDetailViewModel: ViewModel() {
         viewModelScope.launch(Dispatchers.IO) {
             _userData.value = null  // 데이터 로드 전에 null로 초기화
             try {
-                sqlDetailRepository.getUserById(userIdx).collect { user ->
+                detailRepository.getUserById(userIdx).collect { user ->
                     if (user != null) {
                         _userData.value = user
                         Log.d("DetailViewModel", "User data fetched successfully: $user")
@@ -164,7 +163,7 @@ class SqlDetailViewModel: ViewModel() {
 
     fun getTechIdxByStudyIdx(studyIdx: Int) {
         viewModelScope.launch {
-            sqlDetailRepository.getTechIdxByStudyIdx(studyIdx).collect { techList ->
+            detailRepository.getTechIdxByStudyIdx(studyIdx).collect { techList ->
                 _studyTechList.value = techList
             }
         }
@@ -173,7 +172,7 @@ class SqlDetailViewModel: ViewModel() {
     // studyState 값을 업데이트하는 메소드 추가
     fun updateStudyState(studyIdx: Int, newState: Boolean) {
         viewModelScope.launch {
-            val result = sqlDetailRepository.updateStudyState(studyIdx, newState)
+            val result = detailRepository.updateStudyState(studyIdx, newState)
             _updateResult.emit(result)
         }
     }
@@ -181,14 +180,14 @@ class SqlDetailViewModel: ViewModel() {
     // 스터디 데이터를 업데이트하는 함수
     fun updateStudyData(studyData: SqlStudyData) {
         viewModelScope.launch {
-            val result = sqlDetailRepository.updateStudy(studyData)
+            val result = detailRepository.updateStudy(studyData)
             _updateResult.value = result
         }
     }
 
     fun insertSkills(studyIdx: Int, skills: List<Int>) {
         viewModelScope.launch {
-            sqlDetailRepository.insertSkills(studyIdx, skills)
+            detailRepository.insertSkills(studyIdx, skills)
         }
     }
 
@@ -200,7 +199,7 @@ class SqlDetailViewModel: ViewModel() {
     // 특정 사용자를 스터디에서 삭제하는 메소드
     fun removeUserFromStudy(studyIdx: Int, userIdx: Int) {
         viewModelScope.launch {
-            val result = sqlDetailRepository.removeUserFromStudy(studyIdx, userIdx)
+            val result = detailRepository.removeUserFromStudy(studyIdx, userIdx)
             _removeUserResult.emit(result)
         }
     }
@@ -208,9 +207,9 @@ class SqlDetailViewModel: ViewModel() {
     fun addUserToStudyOrRequest(studyIdx: Int, userIdx: Int, applyMethod: String) {
         viewModelScope.launch {
             val result = if (applyMethod == "선착순") {
-                sqlDetailRepository.addUserToStudy(studyIdx, userIdx)
+                detailRepository.addUserToStudy(studyIdx, userIdx)
             } else {
-                sqlDetailRepository.addUserToStudyRequest(studyIdx, userIdx)
+                detailRepository.addUserToStudyRequest(studyIdx, userIdx)
             }
             _addUserResult.emit(result)
         }
@@ -218,14 +217,14 @@ class SqlDetailViewModel: ViewModel() {
 
     fun fetchStudyRequestMembers(studyIdx: Int) {
         viewModelScope.launch {
-            val members = sqlDetailRepository.getStudyRequestMembers(studyIdx)
+            val members = detailRepository.getStudyRequestMembers(studyIdx)
             _studyRequestMembers.value = members
         }
     }
 
     fun acceptUser(studyIdx: Int, userIdx: Int) {
         viewModelScope.launch {
-            val result = sqlDetailRepository.acceptUser(studyIdx, userIdx)
+            val result = detailRepository.acceptUser(studyIdx, userIdx)
             _acceptUserResult.emit(result)
 
             if (result) {
@@ -240,7 +239,7 @@ class SqlDetailViewModel: ViewModel() {
     // 특정 사용자를 스터디 요청에서 삭제하는 메소드
     fun removeUserFromApplyList(studyIdx: Int, userIdx: Int) {
         viewModelScope.launch {
-            val result = sqlDetailRepository.removeUserFromStudyRequest(studyIdx, userIdx)
+            val result = detailRepository.removeUserFromStudyRequest(studyIdx, userIdx)
             _removeUserFromApplyResult.emit(result)
 
             if (result) {
@@ -253,7 +252,7 @@ class SqlDetailViewModel: ViewModel() {
     fun fetchUserProfile(userIdx: Int) {
         viewModelScope.launch {
             try {
-                sqlDetailRepository.getUserById(userIdx).collect { user ->
+                detailRepository.getUserById(userIdx).collect { user ->
                     _userData.value = user
                     // 다른 필요한 데이터 로드 로직을 여기서 추가로 처리
                 }
@@ -293,7 +292,7 @@ class SqlDetailViewModel: ViewModel() {
         viewModelScope.launch {
             try {
                 val newState = if (canApply) "모집중" else "모집완료"
-                val result = sqlDetailRepository.updateStudyCanApplyField(studyIdx, newState)
+                val result = detailRepository.updateStudyCanApplyField(studyIdx, newState)
                 if (result) {
                     // DB 업데이트 성공 시, 별도의 UI 갱신을 하지 않음
                     Log.d("SqlDetailViewModel", "Study state updated successfully.")

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/SqlDetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/SqlDetailViewModel.kt
@@ -13,12 +13,12 @@ import kotlinx.coroutines.launch
 import kr.co.lion.modigm.model.SqlStudyData
 import kr.co.lion.modigm.model.SqlUserData
 import kr.co.lion.modigm.repository.SqlDetailRepository
-import kr.co.lion.modigm.repository.StudyListRepository
+import kr.co.lion.modigm.repository.StudyRepository
 
 class SqlDetailViewModel: ViewModel() {
 
     private val sqlDetailRepository = SqlDetailRepository()
-    private val studyListRepository = StudyListRepository()
+    private val studyRepository = StudyRepository()
 
     private val _studyData = MutableStateFlow<SqlStudyData?>(null)
     val studyData: StateFlow<SqlStudyData?> = _studyData
@@ -266,7 +266,7 @@ class SqlDetailViewModel: ViewModel() {
     // 좋아요 상태 확인 메소드
     fun checkIfLiked(userIdx: Int, studyIdx: Int) {
         viewModelScope.launch {
-            val result = studyListRepository.getFavoriteStudyData(userIdx).getOrNull()?.any { it.first.studyIdx == studyIdx } ?: false
+            val result = studyRepository.getFavoriteStudyData(userIdx).getOrNull()?.any { it.first.studyIdx == studyIdx } ?: false
             _isLiked.value = result
         }
     }
@@ -275,12 +275,12 @@ class SqlDetailViewModel: ViewModel() {
     fun toggleFavoriteStatus(userIdx: Int, studyIdx: Int) {
         viewModelScope.launch {
             if (_isLiked.value) {
-                val result = studyListRepository.removeFavorite(userIdx, studyIdx).getOrNull()
+                val result = studyRepository.removeFavorite(userIdx, studyIdx).getOrNull()
                 if (result == true) {
                     _isLiked.value = false
                 }
             } else {
-                val result = studyListRepository.addFavorite(userIdx, studyIdx).getOrNull()
+                val result = studyRepository.addFavorite(userIdx, studyIdx).getOrNull()
                 if (result == true) {
                     _isLiked.value = true
                 }

--- a/app/src/main/res/layout/fragment_detail_image_zoom.xml
+++ b/app/src/main/res/layout/fragment_detail_image_zoom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- 확대된 이미지 -->
+    <ImageView
+        android:id="@+id/imageViewZoomed"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="fitCenter"
+        android:adjustViewBounds="true"
+        android:contentDescription="이미지" />
+
+    <!-- 둥근 닫기 버튼 -->
+    <ImageButton
+        android:id="@+id/imageViewClose"
+        android:layout_width="34dp"
+        android:layout_height="34dp"
+        android:layout_gravity="top|end"
+        android:layout_margin="10dp"
+        android:background="@drawable/style_round_border"
+        android:src="@drawable/icon_close_24"
+        android:contentDescription="닫기"
+        android:backgroundTint="@android:color/darker_gray"
+        android:elevation="4dp" />
+
+</FrameLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #303 

## 📝작업 내용

1. 스터디 커버 이미지를 눌러 상세 보기 기능을 추가 했습니다.
2. 파일명 변경 (파일명에서 Sql 삭제)

### 스크린샷 (선택)

<img src="https://github.com/user-attachments/assets/5a27edc2-629d-413b-8f0f-949858492dcb" width=250 />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

