### PR TITLE
[#315] feature 공지사항,고객센터,이용약관 웹뷰 띄우기

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileWebFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileWebFragment.kt
@@ -88,6 +88,10 @@ class ProfileWebFragment : VBBaseFragment<FragmentProfileWebBinding>(FragmentPro
         }
 
         webView.settings.javaScriptEnabled = true
+
+        // 로컬 스토리지를 사용하는 페이지일 경우 domStorageEnabled을 true로 셋팅
+        webView.settings.domStorageEnabled = true
+
         webView.loadUrl(link!!)
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/SettingsFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/SettingsFragment.kt
@@ -4,14 +4,17 @@ import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.commit
+import androidx.lifecycle.lifecycleScope
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.launch
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentSettingsBinding
 import kr.co.lion.modigm.ui.DBBaseFragment
 import kr.co.lion.modigm.ui.login.LoginFragment
 import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.JoinType
+import kr.co.lion.modigm.util.Links
 import kr.co.lion.modigm.util.ModigmApplication.Companion.prefs
 
 class SettingsFragment(private val profileFragment: ProfileFragment): DBBaseFragment<FragmentSettingsBinding>(R.layout.fragment_settings) {
@@ -83,6 +86,21 @@ class SettingsFragment(private val profileFragment: ProfileFragment): DBBaseFrag
                 }
             }
 
+            // 공지사항
+            layoutSettingsNotice.setOnClickListener {
+                openWebView(Links.NOTICE.url)
+            }
+
+            // 고객센터
+            layoutSettingsService.setOnClickListener {
+                openWebView(Links.SERVICE.url)
+            }
+
+            // 이용약관
+            layoutSettingsTerms.setOnClickListener {
+                openWebView(Links.TERMS.url)
+            }
+
             // 로그아웃 (오류뜸, clearBackStack 수정 필요)
             layoutSettingsLogout.setOnClickListener {
                 // SharedPreferences 초기화
@@ -95,6 +113,24 @@ class SettingsFragment(private val profileFragment: ProfileFragment): DBBaseFrag
                     .replace(R.id.containerMain, LoginFragment())
                     .addToBackStack(null)
                     .commit()
+            }
+        }
+    }
+
+    private fun openWebView(url: String){
+        viewLifecycleOwner.lifecycleScope.launch {
+            // bundle 에 필요한 정보를 담는다
+            val bundle = Bundle()
+            bundle.putString("link", url)
+
+            // 이동할 프래그먼트로 bundle을 넘긴다
+            val profileWebFragment = ProfileWebFragment()
+            profileWebFragment.arguments = bundle
+
+            // Fragment 교체
+            parentFragmentManager.commit {
+                add(R.id.containerMain, profileWebFragment)
+                addToBackStack(FragmentName.PROFILE_WEB.str)
             }
         }
     }

--- a/app/src/main/java/kr/co/lion/modigm/util/Links.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/Links.kt
@@ -1,0 +1,7 @@
+package kr.co.lion.modigm.util
+
+enum class Links(val url:String) {
+    NOTICE("https://smooth-orangutan-e69.notion.site/0ff98834d23f43269dfab13e15ee88fb?pvs=4"),
+    SERVICE("https://forms.gle/J1qcXTYDzcgB69wQ6"),
+    TERMS("https://smooth-orangutan-e69.notion.site/5c47ca9800114574898502f04b17595f?pvs=4"),
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #315 

## 📝작업 내용

> 공지사항, 이용약관은 모우다임 노션으로 만들었습니다.
> 고객센터는 구글폼으로 이름,이메일,본문 응답을 제출하도록 셋팅하였습니다.
> 노션이 로컬스토리지를 사용하고 있어서 기존의 희원님이 작성하신 웹뷰를 사용하면 페이지가 뜨지 않는 관계로
webView.settings.domStorageEnabled = true 구문을 ProfileWebFragment에 추가해놓았습니다.

### 스크린샷 (선택)
https://github.com/user-attachments/assets/13aba819-c5aa-4807-b7e1-77db74455009


## 💬리뷰 요구사항(선택)

> 이용약관은 끝까지 읽어보시고 수정할만한 부분이 있을지 확인해주시면 좋을 것 같습니다.
공지사항은 내용이 없습니다
> 그리고 웹뷰 실행할 때 코루틴 스코프로 안 감싸도 실행은 되던데 감싸는 이유를 알 수 있을까요?

> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
