### PR TITLE
[#320] [Feature] 스터디 목록 스크롤 시 새로고침 기능

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,4 +143,7 @@ dependencies {
 
     // 리사이클러뷰 스와이프 새로고침
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
+
+    // 스켈레톤 UI
+    implementation("com.facebook.shimmer:shimmer:0.5.0")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -140,4 +140,7 @@ dependencies {
     
     // libphonenumber (국가별 전화번호 변환 대응)
     implementation("com.googlecode.libphonenumber:libphonenumber:8.13.42")
+
+    // 리사이클러뷰 스와이프 새로고침
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
 }

--- a/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDao.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDao.kt
@@ -63,6 +63,7 @@ class RemoteStudyDao {
                     LEFT JOIN tb_study_member sm ON s.studyIdx = sm.studyIdx
                     LEFT JOIN tb_favorite f ON s.studyIdx = f.studyIdx AND f.userIdx = ?
                     WHERE sm.userIdx = ?
+                    AND s.studyState = true
                     GROUP BY s.studyIdx
                 """
                     connection.prepareStatement(query).use { statement ->

--- a/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDao.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/study/RemoteStudyDao.kt
@@ -102,6 +102,7 @@ class RemoteStudyDao {
                 INNER JOIN tb_study s ON f.studyIdx = s.studyIdx
                 LEFT JOIN tb_study_member sm ON s.studyIdx = sm.studyIdx
                 WHERE f.userIdx = ?
+                AND s.studyState = true
                 GROUP BY s.studyIdx
                 """
                     connection.prepareStatement(query).use { statement ->

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/BottomNaviFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/BottomNaviFragment.kt
@@ -192,7 +192,9 @@ class BottomNaviFragment : VBBaseFragment<FragmentBottomNaviBinding>(FragmentBot
             if (childFragmentManager.findFragmentById(R.id.containerBottomNavi) == null) {
                 childFragmentManager.commit {
                     setReorderingAllowed(true)
-                    add(R.id.containerBottomNavi, fragments[FragmentName.STUDY.str]!!, FragmentName.STUDY.str)
+                    fragments[FragmentName.STUDY.str]?.let {
+                        add(R.id.containerBottomNavi, it, FragmentName.STUDY.str)
+                    }
                 }
                 activeFragment = fragments[FragmentName.STUDY.str]
             }

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/BottomNaviFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/BottomNaviFragment.kt
@@ -3,8 +3,8 @@ package kr.co.lion.modigm.ui.study
 import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
+import androidx.fragment.app.replace
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.RecyclerView
 import kr.co.lion.modigm.R
@@ -59,33 +59,25 @@ class BottomNaviFragment : VBBaseFragment<FragmentBottomNaviBinding>(FragmentBot
             private var doubleBackToExitPressedOnce = false
 
             override fun handleOnBackPressed() {
-                // 현재 활성화된 프래그먼트를 확인
-                val currentFragment = childFragmentManager.findFragmentById(R.id.containerBottomNavi)
 
-                // 바텀 내비게이션에 포함된 프래그먼트인지 확인
-                val isBottomNavFragment = currentFragment is StudyFragment
-                        || currentFragment is FavoriteFragment
-                        || currentFragment is ChatFragment
-                        || currentFragment is ProfileFragment
-
-                // 바텀 내비게이션 프래그먼트가 활성화된 경우에만 백버튼 종료 동작 수행
-                if (isBottomNavFragment) {
-                    if (doubleBackToExitPressedOnce) {
-                        requireActivity().finishAffinity()
-                        exitProcess(0) // 앱 프로세스를 완전히 종료
+                with(binding){
+                    if(bottomNavigationView.selectedItemId == R.id.bottomNaviStudy){
+                        if (doubleBackToExitPressedOnce) {
+                            requireActivity().finishAffinity()
+                            exitProcess(0) // 앱 프로세스를 완전히 종료
+                        } else {
+                            doubleBackToExitPressedOnce = true
+                            // Snackbar를 표시하여 사용자에게 알림
+                            requireActivity().showLoginSnackBar("한 번 더 누르면 앱이 종료됩니다.", null)
+                            // 2초 후에 doubleBackToExitPressedOnce 플래그 초기화
+                            view?.postDelayed({ doubleBackToExitPressedOnce = false }, 2000)
+                        }
                     } else {
-                        doubleBackToExitPressedOnce = true
-                        // Snackbar를 표시하여 사용자에게 알림
-                        requireActivity().showLoginSnackBar("한 번 더 누르면 앱이 종료됩니다.", null)
-                        // 2초 후에 doubleBackToExitPressedOnce 플래그 초기화
-                        view?.postDelayed({ doubleBackToExitPressedOnce = false }, 2000)
+                        // 현재 프래그먼트가 StudyFragment가 아닌 경우 StudyFragment로 이동
+                        bottomNavigationView.selectedItemId = R.id.bottomNaviStudy
                     }
-                } else {
-                    // 다른 프래그먼트가 활성화된 경우 기본 백버튼 동작 수행
-                    isEnabled = false
-                    requireActivity().onBackPressedDispatcher.onBackPressed()
-                    isEnabled = true
                 }
+
             }
         }
     }
@@ -164,41 +156,13 @@ class BottomNaviFragment : VBBaseFragment<FragmentBottomNaviBinding>(FragmentBot
         }
     }
 
-    // 현재 보여지고 있는 프래그먼트를 기억하기 위한 변수
-    private var activeFragment: Fragment? = null
-
+    // 현재 선택된 아이템의 인덱스를 기억하기 위한 변수
     private var currentNavItemIndex = 0
 
     // 뷰 초기화 함수
     private fun initView() {
-
-        with(binding) {
-            val fragments = mapOf(
-                FragmentName.STUDY.str to StudyFragment(),
-                FragmentName.LIKE.str to FavoriteFragment(),
-                FragmentName.CHAT.str to ChatFragment().apply {
-                    arguments = Bundle().apply {
-                        putInt("currentUserIdx", prefs.getInt("currentUserIdx"))
-                    }
-                },
-                FragmentName.PROFILE.str to ProfileFragment().apply {
-                    arguments = Bundle().apply {
-                        putInt("userIdx", prefs.getInt("currentUserIdx"))
-                    }
-                }
-            )
-
-            // 초기 프래그먼트 설정
-            if (childFragmentManager.findFragmentById(R.id.containerBottomNavi) == null) {
-                childFragmentManager.commit {
-                    setReorderingAllowed(true)
-                    fragments[FragmentName.STUDY.str]?.let {
-                        add(R.id.containerBottomNavi, it, FragmentName.STUDY.str)
-                    }
-                }
-                activeFragment = fragments[FragmentName.STUDY.str]
-            }
-
+        with(binding){
+            // 스터디 작성 버튼 클릭 시
             fabStudyWrite.setOnClickListener {
                 requireActivity().supportFragmentManager.commit {
                     add(R.id.containerMain, WriteFragment())
@@ -206,7 +170,12 @@ class BottomNaviFragment : VBBaseFragment<FragmentBottomNaviBinding>(FragmentBot
                 }
             }
 
-            // 바텀 네비게이션 아이템 선택 리스너 설정
+            if (childFragmentManager.findFragmentById(R.id.containerBottomNavi) == null) {
+                childFragmentManager.commit {
+                    setReorderingAllowed(true)
+                    replace<StudyFragment>(R.id.containerBottomNavi)
+                }
+            }
             bottomNavigationView.setOnItemSelectedListener { item ->
 
                 val newNavItemIndex = when (item.itemId) {
@@ -222,44 +191,46 @@ class BottomNaviFragment : VBBaseFragment<FragmentBottomNaviBinding>(FragmentBot
                     return@setOnItemSelectedListener true
                 }
 
-                // 애니메이션 방향 설정
-                val enterAnim =
-                    if (newNavItemIndex > currentNavItemIndex) {
-                        R.anim.slide_in_right
-                    } else {
-                        R.anim.slide_in_left
-                    }
-                val exitAnim =
-                    if (newNavItemIndex > currentNavItemIndex) {
-                        R.anim.slide_out_left
-                    } else {
-                        R.anim.slide_out_right
-                    }
-
-                val fragmentToShow = when (item.itemId) {
-                    R.id.bottomNaviStudy -> fragments[FragmentName.STUDY.str]
-                    R.id.bottomNaviHeart -> fragments[FragmentName.LIKE.str]
-                    R.id.bottomNaviChat -> fragments[FragmentName.CHAT.str]
-                    R.id.bottomNaviMy -> fragments[FragmentName.PROFILE.str]
-                    else -> null
-                }
-
-                fragmentToShow?.let { fragment ->
-                    fabStudyWrite.visibility = if (item.itemId == R.id.bottomNaviStudy || item.itemId == R.id.bottomNaviHeart) View.VISIBLE else View.GONE
-
-                    childFragmentManager.commit {
-                        setCustomAnimations(enterAnim, exitAnim, enterAnim, exitAnim)
-                        setReorderingAllowed(true)
-                        activeFragment?.let { hide(it) }
-                        if (!fragment.isAdded) {
-                            add(R.id.containerBottomNavi, fragment, fragment.tag)
+                when(item.itemId) {
+                    R.id.bottomNaviStudy -> {
+                        childFragmentManager.commit {
+                            setReorderingAllowed(true)
+                            replace<StudyFragment>(R.id.containerBottomNavi)
+                            addToBackStack(FragmentName.STUDY.str)
                         }
-                        show(fragment)
                     }
-                    activeFragment = fragment
+                    R.id.bottomNaviHeart -> {
+                        childFragmentManager.commit {
+                            setReorderingAllowed(true)
+                            replace<FavoriteFragment>(R.id.containerBottomNavi)
+                            addToBackStack(FragmentName.LIKE.str)
+                        }
+                    }
+                    R.id.bottomNaviChat -> {
+                        val chatFragment = ChatFragment().apply {
+                            arguments = Bundle().apply {
+                                putInt("currentUserIdx", prefs.getInt("currentUserIdx"))
+                            }
+                        }
+                        childFragmentManager.commit {
+                            setReorderingAllowed(true)
+                            replace(R.id.containerBottomNavi, chatFragment)
+                            addToBackStack(FragmentName.CHAT.str)
+                        }
+                    }
+                    R.id.bottomNaviMy -> {
+                        val profileFragment = ProfileFragment().apply {
+                            arguments = Bundle().apply {
+                                putInt("userIdx", prefs.getInt("currentUserIdx"))
+                            }
+                        }
+                        childFragmentManager.commit {
+                            setReorderingAllowed(true)
+                            replace(R.id.containerBottomNavi, profileFragment)
+                            addToBackStack(FragmentName.PROFILE.str)
+                        }
+                    }
                 }
-
-                // 선택된 아이템 인덱스 업데이트
                 currentNavItemIndex = newNavItemIndex
                 true
             }

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/FavoriteFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/FavoriteFragment.kt
@@ -93,6 +93,16 @@ class FavoriteFragment : VBBaseFragment<FragmentFavoriteBinding>(FragmentFavorit
 //            studyAllAdapter.updateData(studyList)
 //            Log.d("StudyAllFragment", "필터링된 전체 스터디 목록 업데이트: ${studyList.size} 개, 데이터: $studyList")
 //        }
+        // 로딩 상태 관찰
+        viewModel.isLoading.observe(viewLifecycleOwner) { isLoading ->
+            with(binding){
+                if (isLoading) {
+                    progressBarFavorite.visibility = View.VISIBLE
+                } else {
+                    progressBarFavorite.visibility = View.GONE
+                }
+            }
+        }
 
 
         // 전체 데이터 관찰 (필터링이 없을 때)
@@ -143,11 +153,14 @@ class FavoriteFragment : VBBaseFragment<FragmentFavoriteBinding>(FragmentFavorit
     // 오류 다이얼로그 표시
     private fun showStudyErrorDialog(message: String) {
         val dialog = CustomLoginErrorDialog(requireContext())
-        dialog.setTitle("오류")
-        dialog.setMessage(message)
-        dialog.setPositiveButton("확인") {
-            dialog.dismiss()
+        with(dialog){
+            setTitle("오류")
+            setMessage(message)
+            setPositiveButton("확인") {
+                dismiss()
+            }
+            show()
         }
-        dialog.show()
+
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/FavoriteFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/FavoriteFragment.kt
@@ -82,6 +82,7 @@ class FavoriteFragment : VBBaseFragment<FragmentFavoriteBinding>(FragmentFavorit
                 layoutManager = LinearLayoutManager(requireActivity())
 
             }
+
         }
     }
 
@@ -96,15 +97,18 @@ class FavoriteFragment : VBBaseFragment<FragmentFavoriteBinding>(FragmentFavorit
 
         // 전체 데이터 관찰 (필터링이 없을 때)
         viewModel.favoritedStudyData.observe(viewLifecycleOwner) { studyList ->
-            if (studyList.isNotEmpty()) {
-                binding.recyclerviewFavorite.visibility = View.VISIBLE
-                binding.blankLayoutFavorite.visibility = View.GONE
-                studyAdapter.updateData(studyList)
+            with(binding) {
+                if (studyList.isNotEmpty()) {
+                    recyclerviewFavorite.visibility = View.VISIBLE
+                    blankLayoutFavorite.visibility = View.GONE
+                    studyAdapter.updateData(studyList)
 
-            } else {
-                binding.recyclerviewFavorite.visibility = View.GONE
-                binding.blankLayoutFavorite.visibility = View.VISIBLE
+                } else {
+                    recyclerviewFavorite.visibility = View.GONE
+                    blankLayoutFavorite.visibility = View.VISIBLE
+                }
             }
+
         }
 
         viewModel.isFavorite.observe(viewLifecycleOwner) { isFavorite ->

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/FilterSortFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/FilterSortFragment.kt
@@ -4,6 +4,7 @@ import android.content.res.ColorStateList
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import androidx.activity.addCallback
 import androidx.core.content.ContextCompat
 import androidx.core.view.children
 import androidx.fragment.app.activityViewModels
@@ -28,6 +29,8 @@ class FilterSortFragment : VBBaseFragment<FragmentFilterSortBinding>(FragmentFil
 
         // 초기 뷰 세팅
         initView()
+
+        backButton()
     }
 
     // --------------------------------- LC END ---------------------------------
@@ -357,5 +360,11 @@ class FilterSortFragment : VBBaseFragment<FragmentFilterSortBinding>(FragmentFil
             }
         }
 
+    }
+    private fun backButton(){
+        // 백버튼 처리
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            parentFragmentManager.popBackStack()
+        }
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/StudyAllFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/StudyAllFragment.kt
@@ -173,17 +173,31 @@ class StudyAllFragment : VBBaseFragment<FragmentStudyAllBinding>(FragmentStudyAl
 
 
     private fun observeViewModel() {
-        // 이미 관찰자가 등록된 경우를 피하기 위해 조건 추가
+
+        // 로딩 상태 관찰
+        viewModel.isLoading.observe(viewLifecycleOwner) { isLoading ->
+            with(binding){
+                if (isLoading) {
+                    progressBarStudyAll.visibility = View.VISIBLE
+                } else {
+                    progressBarStudyAll.visibility = View.GONE
+                }
+            }
+        }
+
+        // 전체 스터디 목록 관찰
         viewModel.allStudyData.observe(viewLifecycleOwner) { studyList ->
             studyAdapter.updateData(studyList)
             Log.d(tag, "전체 스터디 목록 업데이트: ${studyList.size} 개")
         }
 
+        // 좋아요 상태 관찰
         viewModel.isFavorite.observe(viewLifecycleOwner) { isFavorite ->
             // 좋아요 상태가 변경되었을 때 특정 항목 업데이트
             studyAdapter.updateItem(isFavorite.first, isFavorite.second)
         }
 
+        // 전체 스터디 목록 오류 관찰
         viewModel.allStudyError.observe(viewLifecycleOwner) { e ->
             Log.e(tag, "전체 스터디 목록 오류 발생", e)
             if (e != null) {
@@ -191,6 +205,7 @@ class StudyAllFragment : VBBaseFragment<FragmentStudyAllBinding>(FragmentStudyAl
             }
         }
 
+        // 좋아요 오류 관찰
         viewModel.isFavoriteError.observe(viewLifecycleOwner) { e ->
             Log.e(tag, "좋아요 오류 발생", e)
             if (e != null) {
@@ -213,11 +228,14 @@ class StudyAllFragment : VBBaseFragment<FragmentStudyAllBinding>(FragmentStudyAl
     // 오류 다이얼로그 표시
     private fun studyErrorDialog(message: String) {
         val dialog = CustomLoginErrorDialog(requireContext())
-        dialog.setTitle("오류")
-        dialog.setMessage(message)
-        dialog.setPositiveButton("확인") {
-            dialog.dismiss()
+        with(dialog){
+            setTitle("오류")
+            setMessage(message)
+            setPositiveButton("확인") {
+                dismiss()
+            }
+            show()
         }
-        dialog.show()
+
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/StudyAllFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/StudyAllFragment.kt
@@ -160,6 +160,14 @@ class StudyAllFragment : VBBaseFragment<FragmentStudyAllBinding>(FragmentStudyAl
                     }
                 }
             }
+
+            // 쓸어내려 새로고침 기능
+            with(swipeRefreshLayoutStudyAll){
+                setOnRefreshListener {
+                    viewModel.getAllStudyData()
+                    isRefreshing = false
+                }
+            }
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/StudyMyFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/StudyMyFragment.kt
@@ -148,6 +148,17 @@ class StudyMyFragment : VBBaseFragment<FragmentStudyMyBinding>(FragmentStudyMyBi
 //            Log.d("StudyMyFragment", "필터링된 내 스터디 목록 업데이트: ${studyList.size} 개, 데이터: $studyList")
 //        }
 
+        // 로딩 상태 관찰
+        viewModel.isLoading.observe(viewLifecycleOwner) { isLoading ->
+            with(binding){
+                if (isLoading) {
+                    progressBarStudyMy.visibility = View.VISIBLE
+                } else {
+                    progressBarStudyMy.visibility = View.GONE
+                }
+            }
+        }
+
         // 내 스터디 데이터 관찰 (필터링이 없을 때)
         viewModel.myStudyData.observe(viewLifecycleOwner) { studyList ->
             studyAdapter.updateData(studyList)
@@ -191,11 +202,14 @@ class StudyMyFragment : VBBaseFragment<FragmentStudyMyBinding>(FragmentStudyMyBi
     // 오류 다이얼로그 표시
     private fun studyErrorDialog(message: String) {
         val dialog = CustomLoginErrorDialog(requireContext())
-        dialog.setTitle("오류")
-        dialog.setMessage(message)
-        dialog.setPositiveButton("확인") {
-            dialog.dismiss()
+        with(dialog){
+            setTitle("오류")
+            setMessage(message)
+            setPositiveButton("확인") {
+                dismiss()
+            }
+            show()
         }
-        dialog.show()
+
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/StudyMyFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/StudyMyFragment.kt
@@ -131,7 +131,13 @@ class StudyMyFragment : VBBaseFragment<FragmentStudyMyBinding>(FragmentStudyMyBi
                 }
             }
 
-
+            // 쓸어내려 새로고침 기능
+            with(swipeRefreshLayoutStudyMy){
+                setOnRefreshListener {
+                    viewModel.getMyStudyData()
+                    isRefreshing = false
+                }
+            }
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/vm/StudyViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/vm/StudyViewModel.kt
@@ -28,7 +28,9 @@ class StudyViewModel : ViewModel() {
     private val _allStudyData = MutableLiveData<List<Triple<StudyData, Int, Boolean>>>()
     val allStudyData: LiveData<List<Triple<StudyData, Int, Boolean>>> = _allStudyData
 
-
+    // 로딩 상태를 나타내는 LiveData
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean> = _isLoading
 
     // 내 스터디 리스트
     private val _myStudyData = MutableLiveData<List<Triple<StudyData, Int, Boolean>>>()
@@ -67,6 +69,7 @@ class StudyViewModel : ViewModel() {
      */
     fun getAllStudyData() {
         viewModelScope.launch {
+            _isLoading.value = true // 로딩 시작
             val result = studyRepository.getAllStudyData(getCurrentUserIdx())
             result.onSuccess {
                 _allStudyData.postValue(it)
@@ -74,6 +77,7 @@ class StudyViewModel : ViewModel() {
                 Log.e(tag, "Error getAllStudyData", it)
                 _allStudyError.postValue(it)
             }
+            _isLoading.value = false // 로딩 종료
         }
     }
 
@@ -82,6 +86,7 @@ class StudyViewModel : ViewModel() {
      */
     fun getMyStudyData() {
         viewModelScope.launch {
+            _isLoading.value = true // 로딩 시작
             val result = studyRepository.getMyStudyData(getCurrentUserIdx())
             result.onSuccess {
                 _myStudyData.postValue(it)
@@ -89,6 +94,7 @@ class StudyViewModel : ViewModel() {
                 Log.e(tag, "Error getMyStudyData", e)
                 _myStudyError.postValue(e)
             }
+            _isLoading.value = false // 로딩 종료
         }
     }
 
@@ -97,6 +103,7 @@ class StudyViewModel : ViewModel() {
      */
     fun getFavoriteStudyData() {
         viewModelScope.launch {
+            _isLoading.value = true // 로딩 시작
             val result = studyRepository.getFavoriteStudyData(getCurrentUserIdx())
             result.onSuccess {
                 _favoritedStudyData.postValue(it)
@@ -104,6 +111,7 @@ class StudyViewModel : ViewModel() {
                 Log.e(tag, "Error getFavoriteStudyData", e)
                 _favoriteStudyError.postValue(e)
             }
+            _isLoading.value = false // 로딩 종료
         }
     }
 

--- a/app/src/main/res/layout/fragment_favorite.xml
+++ b/app/src/main/res/layout/fragment_favorite.xml
@@ -1,57 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical"
-    android:paddingHorizontal="16dp"
-    android:paddingVertical="10dp"
-    tools:context=".ui.study.FavoriteFragment"
-    android:background="@color/white">
-
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolBarFavorite"
-        style="@style/CustomToolbar"
-        android:elevation="4dp"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:minHeight="?attr/actionBarSize"
-        android:theme="?attr/actionBarTheme"
-        app:title="찜한 스터디"
-        app:titleTextAppearance="@style/toolbarText" />
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerviewFavorite"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="10dp"/>
+    android:background="@color/white"
+    tools:context=".ui.study.FavoriteFragment">
 
     <LinearLayout
-        android:id="@+id/blankLayoutFavorite"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        android:visibility="gone"
-        tools:visibility="visible">
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="10dp">
 
-        <com.google.android.material.imageview.ShapeableImageView
-            android:layout_width="70dp"
-            android:layout_height="70dp"
-            android:layout_gravity="center"
-            android:layout_marginTop="200dp"
-            app:tint="#ccc"
-            android:src="@drawable/icon_book_24px" />
-
-        <TextView
-            android:layout_width="wrap_content"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolBarFavorite"
+            style="@style/CustomToolbar"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="20dp"
-            android:textColor="@color/textGray"
-            android:text="찜한 스터디 내역이 없어요"
-            android:textSize="18dp"
-            android:textStyle="bold" />
+            android:elevation="4dp"
+            android:minHeight="?attr/actionBarSize"
+            android:theme="?attr/actionBarTheme"
+            app:title="찜한 스터디"
+            app:titleTextAppearance="@style/toolbarText" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerviewFavorite"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="10dp" />
+
+
+        <LinearLayout
+            android:id="@+id/blankLayoutFavorite"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <com.google.android.material.imageview.ShapeableImageView
+                android:layout_width="70dp"
+                android:layout_height="70dp"
+                android:layout_gravity="center"
+                android:layout_marginTop="200dp"
+                android:src="@drawable/icon_book_24px"
+                app:tint="#ccc" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginTop="20dp"
+                android:text="찜한 스터디 내역이 없어요"
+                android:textColor="@color/textGray"
+                android:textSize="18dp"
+                android:textStyle="bold" />
+        </LinearLayout>
+
     </LinearLayout>
 
-</LinearLayout>
+    <ProgressBar
+        android:id="@+id/progressBarFavorite"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminateTint="@color/pointColor"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_study_all.xml
+++ b/app/src/main/res/layout/fragment_study_all.xml
@@ -46,11 +46,17 @@
                     app:tint="@color/black" />
             </LinearLayout>
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recyclerViewStudyAll"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginTop="10dp" />
+            <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+                android:id="@+id/swipeRefreshLayoutStudyAll"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/recyclerViewStudyAll"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_marginTop="10dp" />
+            </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
         </LinearLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_study_all.xml
+++ b/app/src/main/res/layout/fragment_study_all.xml
@@ -3,9 +3,11 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:transitionGroup="true"
     android:background="@color/white">
+
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
@@ -58,5 +60,13 @@
             </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
         </LinearLayout>
+        <ProgressBar
+            android:id="@+id/progressBarStudyAll"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:indeterminateTint="@color/pointColor"
+            android:visibility="gone"
+            tools:visibility="visible" />
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_study_my.xml
+++ b/app/src/main/res/layout/fragment_study_my.xml
@@ -10,12 +10,13 @@
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:paddingHorizontal="16dp"
-            android:paddingTop="16dp">
+            android:paddingVertical="10dp">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -44,11 +45,17 @@
                     android:src="@drawable/icon_filter_24px"
                     app:tint="@color/black" />
             </LinearLayout>
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recyclerViewStudyMy"
+            <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+                android:id="@+id/swipeRefreshLayoutStudyMy"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:padding="8dp" />
+                android:layout_height="match_parent">
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/recyclerViewStudyMy"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_marginTop="10dp" />
+            </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
         </LinearLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_study_my.xml
+++ b/app/src/main/res/layout/fragment_study_my.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -57,5 +58,13 @@
             </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
         </LinearLayout>
+        <ProgressBar
+            android:id="@+id/progressBarStudyMy"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:indeterminateTint="@color/pointColor"
+            android:visibility="gone"
+            tools:visibility="visible" />
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/study_item_shimmer_layout.xml
+++ b/app/src/main/res/layout/study_item_shimmer_layout.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:backgroundTint="@color/cardview_light_background"
+        app:strokeWidth="0dp"
+        android:layout_marginVertical="10dp"
+        android:layout_marginHorizontal="4dp">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="16dp"
+            android:orientation="horizontal">
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="80dp"
+                android:layout_height="80dp"
+                android:layout_marginVertical="16dp"
+                android:backgroundTint="@color/buttonGray"
+                app:strokeWidth="0dp"
+                android:elevation="0dp">
+                <com.google.android.material.imageview.ShapeableImageView
+                    android:id="@+id/imageViewStudyPic"
+                    android:layout_width="80dp"
+                    android:layout_height="80dp"
+                    android:scaleType="centerCrop" />
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:layout_marginVertical="10dp"
+                android:layout_weight="1"
+                android:layout_marginStart="10dp">
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/textView1"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="4dp"
+                        android:layout_gravity="center"
+                        android:background="@color/buttonGray"
+                        android:textSize="14dp"/>
+
+                </LinearLayout>
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/textViewTitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="20dp"
+                    android:layout_marginTop="5dp"
+                    android:background="@color/buttonGray"/>
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="horizontal">
+                    <com.google.android.material.imageview.ShapeableImageView
+                        android:id="@+id/imageViewStudyStudyTypeIcon"
+                        android:layout_width="match_parent"
+                        android:layout_height="20dp"
+                        android:layout_gravity="center"
+                        android:background="@color/buttonGray"
+                        />
+
+
+
+                </LinearLayout>
+
+
+            </LinearLayout>
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+</LinearLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

#320 

## 📝작업 내용

1. 스터디 목록 스크롤 시 새로고침 구현
2. 스터디 목록이 뜨는 모든 리사이클러뷰 로딩 구현
3. 삭제한 스터디 찜목록, 내스터디 에서 안뜨도록 변경
4. 바텀내비 아이템 클릭으로 화면 전환 시 애니메이션 제거(hide/show -> replace)
5. 바텀내비 뒤로가기 로직 변경


### 스크린샷 (선택)

|스크롤 새로고침+로딩|뒤로가기|
|:------------------------:|:---------:|
|<video src ="https://github.com/user-attachments/assets/028fc229-e946-4b5f-b7d8-b7ab9270de96" controls width="200">|<video src ="https://github.com/user-attachments/assets/b00d0ba5-a697-462a-a5f5-dd337d8b8a39" controls width="200">|


## 💬리뷰 요구사항(선택)

### 새로고침

쓸어내려 새로고침 기능 넣어봤습니다. 적용되는 지 테스트 완료했습니다. 추후 써보시고 어색한 부분이 있다면 말씀 부탁드려요!


### 로딩(feat.스켈레톤 UI)

목록에 스터디 적용했습니다. 처음에 스켈레톤 UI를 적용해보려했는데, 데이터가 적어서 로딩이 짧아 이상해서 프로그래스바로 바꿨습니다. 이후 적용하게 될 것을 생각해서 만든 스켈레톤UI구성 코드는 약간 남긴 점 참고 부탁드립니다!(사실 아까워ㅅ...)


### 삭제 스터디 반영

말씀해주신 삭제스터디 뜨는 문제 쿼리 변경으로 개선했습니다. 


### 바텀내비 애니메이션

가장 처음 add 후 다음 접근 시 show/hide 로 전환했었는데, 생명주기가 변하질 않아서 데이터 최신화가 애매하더군요. 빠르게 개선할만한 아이디어가 마땅히 떠오르질 않아서 그냥 replace로 바꾸고 애니메이션은 삭제했습니다. (이유는 replace로 하면 애니메이션 버벅임이 미쳐 날뛰...)
화면전환을 뷰페이저로 바꾼다거나 로컬로 하는 등 개선 방법은 후에 필터 기능 작업 후 여유있을 때 다시 찾아보겠습니다...ㅜㅜ


### 바텀내비 뒤로가기

뒤로가기 로직을 기존엔 구분 없이 두 번 뒤로가기 였었는데, 스터디 외의 아이템이면 스터디로 가도록 하고, 스터디라면 두 번 뒤로가기 종료가 되도록 변경했습니다. 적용 후에 사용 시 어색하다면 지적 부탁드려요 ㅎㅎ

