### PR TITLE
[#325]  파이어베이스 인증 계정이 삭제되는 버그 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinDuplicateFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinDuplicateFragment.kt
@@ -2,9 +2,12 @@ package kr.co.lion.modigm.ui.join
 
 import android.os.Build.VERSION
 import android.os.Bundle
+import android.util.Log
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.commit
 import com.google.firebase.auth.FirebaseUser
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentJoinDuplicateBinding
@@ -13,7 +16,6 @@ import kr.co.lion.modigm.ui.join.vm.JoinStep1ViewModel
 import kr.co.lion.modigm.ui.join.vm.JoinStep2ViewModel
 import kr.co.lion.modigm.ui.join.vm.JoinStep3ViewModel
 import kr.co.lion.modigm.ui.login.LoginFragment
-import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.JoinType
 
 class JoinDuplicateFragment : VBBaseFragment<FragmentJoinDuplicateBinding>(FragmentJoinDuplicateBinding::inflate) {
@@ -45,14 +47,14 @@ class JoinDuplicateFragment : VBBaseFragment<FragmentJoinDuplicateBinding>(Fragm
         settingToolBar()
         settingExistingUserInfo()
         settingButtonJoinDupLogin()
-
+        backButton()
     }
 
     private fun settingToolBar(){
         with(binding.toolbarJoinDup){
             setNavigationIcon(R.drawable.arrow_back_24px)
             setNavigationOnClickListener {
-                parentFragmentManager.popBackStack(FragmentName.JOIN_DUPLICATE.str, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                backPressedCallback.handleOnBackPressed()
             }
         }
     }
@@ -87,6 +89,39 @@ class JoinDuplicateFragment : VBBaseFragment<FragmentJoinDuplicateBinding>(Fragm
             parentFragmentManager.beginTransaction()
                 .replace(R.id.containerMain, LoginFragment())
                 .commit()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        // 백버튼 콜백 제거
+        backPressedCallback.remove()
+    }
+
+    // 백버튼 콜백
+    private val backPressedCallback by lazy {
+        object : OnBackPressedCallback(true) {
+
+            override fun handleOnBackPressed() {
+
+                val joinFragment = parentFragmentManager.fragments[0]
+
+                parentFragmentManager.commit {
+                    joinFragment?.let {
+                        show(joinFragment)
+                    }
+                    hide(this@JoinDuplicateFragment)
+                }
+
+            }
+        }
+    }
+
+    // 백버튼 종료 동작
+    private fun backButton() {
+        // 백버튼 콜백을 안전하게 추가
+        backPressedCallback.let { callback ->
+            requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, callback)
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -60,6 +60,10 @@ class JoinFragment : DBBaseFragment<FragmentJoinBinding>(R.layout.fragment_join)
         settingToolBar()
         settingCollector()
 
+        // 로그인 상태인 경우 미리 로그아웃 처리해주기
+        // 로그인 상태에서 회원가입 진입 후 다시 빠져나올때 로그인된 계정이 파이어베이스 인증에서 삭제될 수 있음
+        viewModel.signOut()
+
         return binding.root
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -12,6 +12,7 @@ import android.view.WindowManager
 import android.widget.TextView
 import androidx.activity.addCallback
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
@@ -389,12 +390,17 @@ class JoinFragment : DBBaseFragment<FragmentJoinBinding>(R.layout.fragment_join)
                 bundle.putString("email", viewModel.alreadyRegisteredUserEmail.value)
                 bundle.putString("provider", viewModel.alreadyRegisteredUserProvider.value)
                 bundle.putParcelable("user", viewModel.user.value)
-                val joinFragment = JoinDuplicateFragment()
-                joinFragment.arguments = bundle
-                parentFragmentManager.beginTransaction()
-                    .replace(R.id.containerMain, joinFragment)
-                    .addToBackStack(FragmentName.JOIN_DUPLICATE.str)
-                    .commit()
+                val joinDupFragment = JoinDuplicateFragment()
+                joinDupFragment.arguments = bundle
+                parentFragmentManager.commit {
+                    hide(this@JoinFragment)
+                    if(joinDupFragment.isAdded){
+                        show(joinDupFragment)
+                    }else{
+                        add(R.id.containerMain, joinDupFragment)
+                    }
+                }
+                viewModel.setIsPhoneAlreadyRegistered(false)
             }
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #325 

## 📝작업 내용

> 자동로그인이 아닌 상태에서 로그아웃이 아닌 그냥 앱 종료 후에 회원가입에 진입했다가 취소할 경우 파이어베이스 인증 계정이 삭제되는 버그를 수정했습니다.
> 또한 계정중복안내프래그먼트를 보여주는 방식을 replace가 아니라 hide,show 방식으로 변경했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
