### PR TITLE
[#335] bug sns 계정 회원가입 시 전화번호 통합이 안되는 버그

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -44,7 +44,7 @@ class JoinFragment : DBBaseFragment<FragmentJoinBinding>(R.layout.fragment_join)
     private val viewModelStep2: JoinStep2ViewModel by activityViewModels()
     private val viewModelStep3: JoinStep3ViewModel by activityViewModels()
 
-    private val joinType: JoinType? by lazy {
+    private val joinType: JoinType by lazy {
         JoinType.getType(arguments?.getString("joinType")?:"")
     }
 
@@ -60,9 +60,16 @@ class JoinFragment : DBBaseFragment<FragmentJoinBinding>(R.layout.fragment_join)
         settingToolBar()
         settingCollector()
 
-        // 로그인 상태인 경우 미리 로그아웃 처리해주기
-        // 로그인 상태에서 회원가입 진입 후 다시 빠져나올때 로그인된 계정이 파이어베이스 인증에서 삭제될 수 있음
-        viewModel.signOut()
+        /**
+         * SNS계정은 자동로그인이 강제되기때문에 앱을 껏다 켜도 로그아웃을 직접 하지 않는 이상 회원가입 화면에 진입할 수 없음
+         * 이메일 계정은 자동로그인을 안하고 로그인을 할 수 있기 때문에 앱을 끄고 다시 켜면 회원가입 화면으로 진입할 수 있음
+         * 이 때 앱의 파이어베이스인증 객체에서는 로그아웃을 직접 하지 않는 이상 아직 이메일 계정으로 로그인된 상태로 인식함
+         * 따라서 이메일 회원가입인 경우에만 signOut을 한번 더 회원가입 진입 시 처리해줌
+         * 안그러면 이미 로그인된 계정이 있을 때 회원가입 화면에서 나갈 때 계정이 파이어베이스 인증 등록에서 삭제될 수 있음
+         */
+        if(joinType==JoinType.EMAIL){
+            viewModel.signOut()
+        }
 
         // sms 인증 코드 발송 시 보여줄 프로그래스바 익명함수를 viewModelStep2에 전달
         viewModelStep2.hideCallback.value = hideLoading

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
@@ -174,14 +174,9 @@ class JoinStep2ViewModel @Inject constructor(
             try{
                 _errorMessage.value = ""
                 val phoneCredential = PhoneAuthProvider.getCredential(_verificationId.value, inputSmsCode.value)
-                val linkedProviders = _auth.currentUser?.providerData?.map { it.providerId }
+                val linkedProviders = _auth.currentUser?.providerData?.find { it.providerId == PhoneAuthProvider.PROVIDER_ID }
                 if (linkedProviders != null) {
-                    for(provider in linkedProviders){
-                        if(provider == "phone"){
-                            _auth.currentUser?.unlink("phone")
-                            break
-                        }
-                    }
+                    _auth.currentUser?.unlink(PhoneAuthProvider.PROVIDER_ID)
                 }
                 _auth.currentUser?.linkWithCredential(phoneCredential)?.await()
             }catch (e: FirebaseAuthException){


### PR DESCRIPTION
## #️⃣연관된 이슈

> #335 

## 📝작업 내용

> sns 계정 회원가입 시 전화번호 통합이 안되는 버그가 있었는데 
> 회원가입 화면 진입 시 기존의 로그인 되었던 계정을 signout처리를 해주는 코드때문에 회원가입을 진행하면서 전화번호 인증 계정과 통합이 안되었던 것으로 확인했습니다.
> 이메일 계정 회원가입인 경우에만 미리 signout을 하는 로직으로 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
