### PR TITLE
[fix #367] 이미지 업로드 s3로 변경, 스터디 커버 사진 변경시 기존 이미지 s3에서 삭제

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/db/detail/RemoteDetailDataSource.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/detail/RemoteDetailDataSource.kt
@@ -204,5 +204,24 @@ class RemoteDetailDataSource {
         }
     }
 
+    // studyPic 업데이트하는 메서드 추가
+    suspend fun updateStudyPic(studyIdx: Int, imageUrl: String): Boolean {
+        return try {
+            studyDao.updateStudyPic(studyIdx, imageUrl) > 0
+        } catch (e: Exception) {
+            Log.e("RemoteDetailDataSource Error", "Error updating studyPic: ${e.message}")
+            false
+        }
+    }
+
+    // S3에 저장된 이미지를 삭제하는 메서드
+    suspend fun deleteImageFromS3(fileName: String): Boolean {
+        return try {
+            studyDao.deleteImageFromS3(fileName)
+        } catch (e: Exception) {
+            Log.e("RemoteDetailDataSource", "Error deleting image from S3: ${e.message}")
+            false
+        }
+    }
 
 }

--- a/app/src/main/java/kr/co/lion/modigm/repository/DetailRepository.kt
+++ b/app/src/main/java/kr/co/lion/modigm/repository/DetailRepository.kt
@@ -124,4 +124,14 @@ class DetailRepository {
     suspend fun isAlreadyApplied(userIdx: Int, studyIdx: Int): Boolean {
         return remoteDetailDataSource.checkExistingApplication(userIdx, studyIdx)
     }
+
+    // 이미지 URL로 studyPic을 업데이트하는 메서드 추가
+    suspend fun updateStudyPic(studyIdx: Int, imageUrl: String): Boolean {
+        return remoteDetailDataSource.updateStudyPic(studyIdx, imageUrl)
+    }
+
+    // S3에 저장된 이미지를 삭제하는 메서드
+    suspend fun deleteImageFromS3(fileName: String): Boolean {
+        return remoteDetailDataSource.deleteImageFromS3(fileName)
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #367 

## 📝작업 내용

1. 이미지 업로드 부분이 firebase storage로 되어있어 s3로 변경

2. 글 수정 화면에서 스터디 커버사진 변경 시 기존 s3에 저장된 커버사진 삭제 후 새 사진 업로드 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
