### PR TITLE
[Fix] #376 전화 인증 기능 버그 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -310,6 +310,17 @@ class JoinFragment : DBBaseFragment<FragmentJoinBinding>(R.layout.fragment_join)
     }
 
     private fun step2Process(){
+        // 뒤로가기로 돌아왔을 때 이미 인증된 상태인 경우에는 바로 다음페이지로 넘어갈 수 있음
+        // 전화번호를 변경하지 않은 경우에만 넘어갈 수 있음
+        if(viewModel.verifiedPhoneNumber.value == viewModelStep2.userPhone.value){
+            if(joinType==JoinType.EMAIL){
+                binding.viewPagerJoin.setCurrentItemWithDuration(3, 300)
+            }else{
+                binding.viewPagerJoin.setCurrentItemWithDuration(2, 300)
+            }
+            return
+        }
+
         // 유효성 검사
         val validation = viewModelStep2.validate()
         if(!validation) return
@@ -320,14 +331,6 @@ class JoinFragment : DBBaseFragment<FragmentJoinBinding>(R.layout.fragment_join)
         )
 
         lifecycleScope.launch {
-            // 뒤로가기로 돌아왔을 때 이미 인증된 상태인 경우에는 바로 다음페이지로 넘어갈 수 있음
-            if(viewModel.phoneVerification.value==true){
-                // 전화번호를 변경하지 않은 경우에 넘어갈 수 있음
-                if(viewModel.verifiedPhoneNumber.value == viewModelStep2.userPhone.value){
-                    binding.viewPagerJoin.setCurrentItemWithDuration(2, 300)
-                    return@launch
-                }
-            }
             showLoading()
 
             val result = viewModelStep2.createPhoneUser()
@@ -407,13 +410,18 @@ class JoinFragment : DBBaseFragment<FragmentJoinBinding>(R.layout.fragment_join)
             hideLoading()
             if(isVerified){
                 // 인증이 되었으면 다음으로 이동
-                viewModelStep2.cancelTimer()
                 if(joinType==JoinType.EMAIL){
                     binding.viewPagerJoin.setCurrentItemWithDuration(3, 300)
                 }else{
                     binding.viewPagerJoin.setCurrentItemWithDuration(2, 300)
                 }
-
+                // 인증 관련 초기화
+                viewModelStep2.apply {
+                    resetIsCodeSent()
+                    resetValidationText()
+                    cancelTimer()
+                }
+                viewModel.setPhoneVerified(false)
             }
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #376 

## 📝작업 내용

> 회원가입 시 전화 인증 단계에서 한번 인증을 완료한 후에 다시 돌아가서 전화번호를 변경하고 인증을 하게되면 기존 전화번호를 수정하지 못하고 에러가 발생하여 전화번호 인증 로직을 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
