### PR TITLE
[feature #388] 3차 테스트 피드백 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/db/detail/RemoteDetailDao.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/detail/RemoteDetailDao.kt
@@ -208,7 +208,9 @@ class RemoteDetailDao {
                 connection.prepareStatement(query).use { statement ->
                     statement.setInt(1, studyIdx)
                     statement.setInt(2, userIdx)
-                    return@withContext statement.executeUpdate() > 0
+                    val result = statement.executeUpdate() > 0
+                    Log.d(TAG, "removeUserFromStudy: Deletion successful: $result")
+                    return@withContext result
                 }
             }
         } catch (e: Exception) {
@@ -301,7 +303,9 @@ class RemoteDetailDao {
                 connection.prepareStatement(query).use { statement ->
                     statement.setInt(1, studyIdx)
                     statement.setInt(2, userIdx)
-                    return@withContext statement.executeUpdate() > 0
+                    val result = statement.executeUpdate() > 0
+                    Log.d(TAG, "removeUserFromStudyRequest: Deletion successful: $result")
+                    return@withContext result
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/kr/co/lion/modigm/model/NotificationData.kt
+++ b/app/src/main/java/kr/co/lion/modigm/model/NotificationData.kt
@@ -11,7 +11,8 @@ data class NotificationData(
     val coverPhotoUrl: String?,
     val notificationTime: Date,
     val studyIdx: Int,
-    var isNew: Boolean = true // 알림이 새로운지 여부를 나타내는 속성
+    var isNew: Boolean = true, // 알림이 새로운지 여부를 나타내는 속성
+    var isRead: Boolean = false
 ) {
     companion object {
         fun getNotificationData(resultSet: ResultSet): NotificationData {

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailEditFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailEditFragment.kt
@@ -972,6 +972,7 @@ class DetailEditFragment : VBBaseFragment<FragmentDetailEditBinding>(FragmentDet
             studyPic = imageFileName,
             studyMaxMember = binding.editTextDetailEditMember.text.toString().toInt(),
             studyState = currentStudyData?.studyState ?: true,
+            studyChatLink = binding.editTextDetailEditLink.text.toString(),
             userIdx = currentStudyData?.userIdx ?: -1
         )
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -33,6 +33,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kr.co.lion.modigm.R
@@ -47,6 +48,7 @@ import kr.co.lion.modigm.util.Links
 import kr.co.lion.modigm.util.ModigmApplication
 import kr.co.lion.modigm.util.Skill
 import kr.co.lion.modigm.util.openWebView
+import kotlinx.coroutines.flow.collect
 
 class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBinding::inflate) {
 
@@ -128,6 +130,8 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
         binding.imageViewDetailCover.setOnClickListener {
             showImageZoomDialog()
         }
+
+//        observeApplyButton()
 
     }
 
@@ -222,6 +226,9 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
                     currentStudyData = it
                     // 스터디 데이터를 수신한 후 사용자 데이터를 요청
                     viewModel.getUserById(it.userIdx)
+                    // 데이터가 로드된 후에 버튼 상태를 설정
+                    setupApplyButton()
+
                     updateUI(it)
 
                     // 링크 데이터 설정
@@ -819,7 +826,11 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
                 when {
                     isAlreadyMember -> showSnackbar(view, "이미 참여중인 스터디입니다.")
                     isAlreadyApplied -> showSnackbar(view, "이미 신청한 스터디입니다.")
-                    success -> showSnackbar(view, "성공적으로 신청되었습니다.")
+                    success -> {
+                        showSnackbar(view, "성공적으로 신청되었습니다.")
+                        setupApplyButton()
+                        refreshScreen()  // 신청 후 화면 갱신
+                    }
                     else -> showSnackbar(view, "신청에 실패하였습니다.")
                 }
             }
@@ -894,6 +905,86 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
             // "모집완료" 상태로 업데이트
             viewModel.updateStudyCanApplyInBackground(studyIdx, false)
         }
+    }
+
+    private fun setupApplyButton() {
+        lifecycleScope.launch {
+            // 글 작성자인지 확인
+            val isOwner = currentStudyData?.userIdx == userIdx
+
+            if (isOwner) {
+                // 작성자는 버튼 비활성화하고 '멤버관리'로 설정
+                binding.buttonDetailApply.text = "멤버관리"
+                binding.buttonDetailApply.isEnabled = true
+                binding.buttonDetailApply.setOnClickListener {
+                    navigateToMemberFragment()
+                }
+            } else {
+                // 비작성자인 경우: 신청 상태에 따라 버튼을 설정
+                val isMember = viewModel.checkIfUserAlreadyMember(studyIdx, userIdx)
+                val isApplied = viewModel.isAlreadyApplied(userIdx, studyIdx)
+
+                // 버튼 상태 업데이트
+                when {
+                    isMember -> {
+                        // 스터디 탈퇴 버튼 설정
+                        binding.buttonDetailApply.text = "스터디 탈퇴"
+                        binding.buttonDetailApply.setOnClickListener {
+                            leaveStudy()
+                        }
+                    }
+                    isApplied -> {
+                        // 신청 취소 버튼 설정
+                        binding.buttonDetailApply.text = "신청 취소"
+                        binding.buttonDetailApply.setOnClickListener {
+                            cancelStudyApplication()
+                        }
+                    }
+                    else -> {
+                        // 신청하기 버튼 설정
+                        binding.buttonDetailApply.text = "신청하기"
+                        binding.buttonDetailApply.setOnClickListener {
+                            handleNonOwnerButtonClick(it)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun cancelStudyApplication() {
+        lifecycleScope.launch {
+            val success = viewModel.removeUserFromApplyList(studyIdx, userIdx)
+            if (success) {
+                showSnackbar(requireView(), "스터디 신청이 취소되었습니다.")
+                setupApplyButton() // 버튼 상태 업데이트
+                refreshScreen() // 화면 갱신
+            } else {
+                showSnackbar(requireView(), "신청 취소에 실패했습니다.")
+            }
+        }
+    }
+
+    private fun leaveStudy() {
+        lifecycleScope.launch {
+            val success = viewModel.removeUserFromStudy(studyIdx, userIdx)
+            if (success) {
+                showSnackbar(requireView(), "스터디에서 탈퇴하였습니다.")
+                setupApplyButton() // 버튼 상태 업데이트
+                refreshScreen() // 화면 갱신
+            } else {
+                showSnackbar(requireView(), "스터디 탈퇴에 실패했습니다.")
+            }
+        }
+    }
+
+    private fun refreshScreen() {
+        // 데이터를 다시 불러옵니다
+        viewModel.clearLoadingState()  // 상태 초기화
+        viewModel.loadStudyData(studyIdx)
+
+        // UI 업데이트를 다시 호출
+        fetchDataAndUpdateUI()
     }
 
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -529,7 +529,7 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
 
             // 뒤로 가기
             toolbar.setNavigationOnClickListener {
-                parentFragmentManager.popBackStack()
+                requireActivity().supportFragmentManager.popBackStack(FragmentName.BOTTOM_NAVI.str, 0)
             }
         }
     }

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -970,6 +970,7 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
             val success = viewModel.removeUserFromStudy(studyIdx, userIdx)
             if (success) {
                 showSnackbar(requireView(), "스터디에서 탈퇴하였습니다.")
+                viewModel.notificationUserLeave(requireContext(), userIdx, studyIdx) // 탈퇴 알림 전송
                 setupApplyButton() // 버튼 상태 업데이트
                 refreshScreen() // 화면 갱신
             } else {

--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/vm/DetailViewModel.kt
@@ -298,26 +298,15 @@ class DetailViewModel: ViewModel() {
     }
 
     // 특정 사용자를 스터디에서 삭제하는 메소드
-    fun removeUserFromStudy(studyIdx: Int, userIdx: Int) {
-        viewModelScope.launch {
-            val result = detailRepository.removeUserFromStudy(studyIdx, userIdx)
-            _removeUserResult.emit(result)
+    fun removeUserFromStudy(studyIdx: Int, userIdx: Int): Boolean {
+        return runBlocking {
+            val success = detailRepository.removeUserFromStudy(studyIdx, userIdx)
+            _removeUserResult.emit(success)
+            return@runBlocking success  // 성공 여부 반환
         }
     }
 
     // 사용자가 이미 스터디에 참여 중인지 확인하는 함수
-//    fun checkIfUserAlreadyMember(studyIdx: Int, userIdx: Int) {
-//        viewModelScope.launch {
-//            try {
-//                // DetailRepository를 통해 해당 사용자가 스터디 멤버인지 체크
-//                val isMember = detailRepository.isUserAlreadyMember(studyIdx, userIdx).firstOrNull() ?: false
-//                _isUserAlreadyMember.value = isMember
-//            } catch (e: Exception) {
-//                Log.e("DetailViewModel", "Error checking if user is already a member", e)
-//                _isUserAlreadyMember.value = false
-//            }
-//        }
-//    }
     // Boolean 값을 반환하는 메소드로 수정
     suspend fun checkIfUserAlreadyMember(studyIdx: Int, userIdx: Int): Boolean {
         return try {
@@ -572,15 +561,16 @@ fun notifyUserKicked(context: Context, userIdx: Int, studyIdx: Int, studyTitle: 
     }
 
     // 특정 사용자를 스터디 요청에서 삭제하는 메소드
-    fun removeUserFromApplyList(studyIdx: Int, userIdx: Int) {
-        viewModelScope.launch {
-            val result = detailRepository.removeUserFromStudyRequest(studyIdx, userIdx)
-            _removeUserFromApplyResult.emit(result)
+    fun removeUserFromApplyList(studyIdx: Int, userIdx: Int): Boolean {
+        return runBlocking {
+            val success = detailRepository.removeUserFromStudyRequest(studyIdx, userIdx)
+            _removeUserFromApplyResult.emit(success)
 
-            if (result) {
+            if (success) {
                 // 신청자 리스트를 다시 로드
                 fetchStudyRequestMembers(studyIdx)
             }
+            return@runBlocking success  // 성공 여부 반환
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/notification/NotificationService.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/notification/NotificationService.kt
@@ -47,6 +47,9 @@ class NotificationService : FirebaseMessagingService(){
             }
         }
 
+        // 배지 상태 저장 (알림이 도착했으므로 true로 설정)
+        prefs.setBoolean("hasUnreadNotifications", true)
+
         // 화면을 갱신하도록 브로드캐스트를 보냄
         notifyDataChanged()
     }

--- a/app/src/main/java/kr/co/lion/modigm/ui/notification/adapter/NotificationAdapter.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/notification/adapter/NotificationAdapter.kt
@@ -115,6 +115,10 @@ class NotificationAdapter(
                     addToBackStack("DETAIL") // Fragment 이름을 추가하여 백스택에 저장
                 }
 
+                // 클릭한 항목만 읽음 상태로 업데이트
+                notification.isNew = false
+                notifyItemChanged(adapterPosition) // 변경된 항목만 갱신
+
                 // 서버에 상태 업데이트 호출
                 onMarkAsRead(notification)
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileWebFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileWebFragment.kt
@@ -1,13 +1,18 @@
 package kr.co.lion.modigm.ui.profile
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.TypedValue
 import android.view.LayoutInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.TextView
+import androidx.core.util.TypedValueCompat.dpToPx
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import kr.co.lion.modigm.R
@@ -30,18 +35,18 @@ class ProfileWebFragment : VBBaseFragment<FragmentProfileWebBinding>(FragmentPro
         binding.toolbarProfileWeb.apply {
             // 툴바 메뉴
             inflateMenu(R.menu.menu_profile_web)
-            setOnMenuItemClickListener {
-                when (it.itemId) {
-                    R.id.menu_item_profile_web_finish -> {
-                        // 이전 프래그먼트로 돌아간다
-                        requireActivity().supportFragmentManager.popBackStack()
-                    }
+            // 메뉴 항목의 actionView에서 클릭 이벤트 처리
+            post {
+                val menuItem = menu.findItem(R.id.menu_item_profile_web_finish)
+                val actionView = menuItem.actionView
+
+                actionView?.setOnClickListener {
+                    // 메뉴 항목 클릭 시 동작할 코드
+                    requireActivity().supportFragmentManager.popBackStack()
                 }
-                true
             }
         }
     }
-
     fun initWebView() {
         val link = arguments?.getString("link")
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/study/BottomNaviFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/study/BottomNaviFragment.kt
@@ -158,12 +158,11 @@ class BottomNaviFragment : VBBaseFragment<FragmentBottomNaviBinding>(FragmentBot
         // 화면이 다시 보일 때 현재 보여지는 프래그먼트를 기준으로 FAB 상태를 업데이트
         updateFabVisibilityBasedOnCurrentFragment()
 
-        // 화면이 다시 보일 때 알림을 확인하지 않았다면 배지를 유지
-        if (shouldShowNotificationBadge()) {
-            showNotificationBadge(true)
-        } else {
-            showNotificationBadge(false)
-        }
+        // SharedPreferences에서 읽지 않은 알림이 있는지 확인
+        val hasUnreadNotifications = prefs.getBoolean("hasUnreadNotifications", false)
+
+        // 배지 상태를 업데이트
+        showNotificationBadge(hasUnreadNotifications)
 
 
     }
@@ -291,6 +290,10 @@ class BottomNaviFragment : VBBaseFragment<FragmentBottomNaviBinding>(FragmentBot
                             }
                         }
                         R.id.bottomNaviNotification -> {
+                            // 알림 화면으로 이동할 때, 알림 상태를 읽음으로 처리
+                            prefs.setBoolean("hasUnreadNotifications", false) // 알림 읽음 상태로 변경
+                            showNotificationBadge(false) // 배지 숨기기
+
                             // FAB 숨기기
                             fabStudyWrite.hide()
                             val notificationFragment = NotificationFragment().apply {

--- a/app/src/main/res/layout/custom_menu_item.xml
+++ b/app/src/main/res/layout/custom_menu_item.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center"
+    android:clickable="true"
+    android:focusable="true">
+
+    <TextView
+        android:id="@+id/menu_item_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="완료"
+        android:textSize="20dp"
+        android:paddingRight="16dp"
+        android:textColor="@android:color/black"/>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_profile_web.xml
+++ b/app/src/main/res/layout/fragment_profile_web.xml
@@ -3,7 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:background="@color/white"
     tools:context=".ui.profile.ProfileWebFragment">
@@ -15,7 +14,6 @@
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
         android:theme="?attr/actionBarTheme"
-        app:titleTextAppearance="@style/toolbarText"
         android:fitsSystemWindows="true"/>
 
     <com.google.android.material.divider.MaterialDivider

--- a/app/src/main/res/layout/fragment_profile_web.xml
+++ b/app/src/main/res/layout/fragment_profile_web.xml
@@ -15,7 +15,8 @@
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
         android:theme="?attr/actionBarTheme"
-        app:titleTextAppearance="@style/toolbarText" />
+        app:titleTextAppearance="@style/toolbarText"
+        android:fitsSystemWindows="true"/>
 
     <com.google.android.material.divider.MaterialDivider
         android:layout_width="match_parent"
@@ -24,6 +25,7 @@
     <WebView
         android:id="@+id/profileWebView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:fitsSystemWindows="true"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/row_notification.xml
+++ b/app/src/main/res/layout/row_notification.xml
@@ -90,6 +90,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="내용"
+                    android:maxLines="2"
+                    android:ellipsize="end"
                     android:textColor="@color/textGray"
                     android:textSize="14dp" />
 

--- a/app/src/main/res/menu/menu_profile_web.xml
+++ b/app/src/main/res/menu/menu_profile_web.xml
@@ -4,5 +4,6 @@
     <item
         android:id="@+id/menu_item_profile_web_finish"
         android:title="완료"
-        app:showAsAction="always" />
+        app:showAsAction="always"
+        app:actionLayout="@layout/custom_menu_item"/>
 </menu>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #388

## 📝작업 내용

1. 글 수정시 오픈 채팅 링크 사라짐, 링크 추가해도 저장 안되는 현상 수정
2. 알림 부분 글자 수 넘어갈 시 ... 생략 필요 maxLines, ellipsize설정 추가
3. 푸쉬 알림을 누르지 않고 앱을 실행 한 경우 바텀 네비 알림 탭에 배지가 안보이는 현상
4. detailfragment에서 링크를 클릭하거나 신고하기 버튼 클릭시 툴바가 잘려보이는 현상 수정
detailfragment를 통해서 웹뷰를 사용하는 경우 툴바가 반정도 잘려보이는 현상이 있었는데 fitsSystemWindows 속성을 사용해 수정했습니다.

5. 웹뷰의 툴바 완료 메뉴 글씨 크기 수정
툴바가 잘리는 현상 때문에 xml파일 수정하면서 해당 부분 수정해뒀습니다

6. 스터디 신청 취소, 탈퇴 기능 추가

### 스크린샷 (선택)
|툴바 수정 및 메뉴 text크기 수정|
|--|
|<img src="https://github.com/user-attachments/assets/0377581a-f97f-41f9-9a6b-20b4cc60314a" width=300 /> |

|신청 취소, 스터디 탈퇴|
|:-----------------:|
|<video src="https://github.com/user-attachments/assets/a7908c6b-1f6c-4cd2-8d59-c310a12ad1bc" controls="controls" style="max-width: 100%; height: auto;"></video>|


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
