### PR TITLE
[#391] fix 회원탈퇴가 안되는 버그 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/db/profile/RemoteProfileDao.kt
+++ b/app/src/main/java/kr/co/lion/modigm/db/profile/RemoteProfileDao.kt
@@ -397,35 +397,6 @@ class RemoteProfileDao {
                     // 수동으로 트랜잭션 시작
                     connection.autoCommit = false
                     try{
-                        // notification 관련 테이블 행 삭제
-                        connection.prepareStatement("DELETE FROM tb_notification WHERE userIdx = ?;").apply {
-                            setInt(1, userIdx)
-                        }.executeUpdate()
-
-                        // 스터디 관련 테이블 행 삭제
-                        connection.prepareStatement("DELETE FROM tb_favorite WHERE userIdx = ?;").apply {
-                            setInt(1, userIdx)
-                        }.executeUpdate()
-                        connection.prepareStatement("DELETE FROM tb_study_request WHERE userIdx = ?;").apply {
-                            setInt(1, userIdx)
-                        }.executeUpdate()
-                        connection.prepareStatement("DELETE FROM tb_study_tech_stack WHERE studyIdx IN ( SELECT studyIdx FROM tb_study WHERE userIdx = ? );").apply {
-                            setInt(1, userIdx)
-                        }.executeUpdate()
-                        connection.prepareStatement("DELETE FROM tb_study_member WHERE studyIdx IN ( SELECT studyIdx FROM tb_study WHERE userIdx = ? );").apply {
-                            setInt(1, userIdx)
-                        }.executeUpdate()
-                        connection.prepareStatement("DELETE FROM tb_study WHERE userIdx = ?;").apply {
-                            setInt(1, userIdx)
-                        }.executeUpdate()
-
-                        // 회원 관련 테이블 행 삭제
-                        connection.prepareStatement("DELETE FROM tb_user_fcm WHERE userIdx = ?;").apply {
-                            setInt(1, userIdx)
-                        }.executeUpdate()
-                        connection.prepareStatement("DELETE FROM tb_user_link WHERE userIdx = ?;").apply {
-                            setInt(1, userIdx)
-                        }.executeUpdate()
                         connection.prepareStatement("DELETE FROM tb_user WHERE userIdx = ?;").apply {
                             setInt(1, userIdx)
                         }.executeUpdate()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #391 

## 📝작업 내용

> 테이블의 제약조건 때문에 delete 구문이 실행되지 않아 회원탈퇴가 진행되지 않은 부분을 수정했습니다.
> 성원님이 각 테이블 제약조건에 ON DELETE CASCADE를 추가해주셔서 tb_user 테이블의 행만 삭제되면 관련된 테이블의 행도 같이 삭제됩니다.
> tb_favorite, tb_notification, tb_study, tb_study_member, tb_study_request, tb_study_tech_stack, tb_user, tb_user_fcm, tb_user_link 모든 테이블에 데이터를 추가한 후에 회원탈퇴를 시도하니 정상적으로 삭제가 되는 것을 확인했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
