### PR TITLE
[#385] Fix 파이어베이스 인증 정보 삭제가 안되는 버그 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinDuplicateFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinDuplicateFragment.kt
@@ -9,6 +9,10 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
 import com.google.firebase.auth.FirebaseUser
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentJoinDuplicateBinding
 import kr.co.lion.modigm.ui.VBBaseFragment
@@ -81,7 +85,12 @@ class JoinDuplicateFragment : VBBaseFragment<FragmentJoinDuplicateBinding>(Fragm
             viewModelStep1.reset()
             viewModelStep2.reset()
             viewModelStep3.reset()
-            currentUser?.delete()
+
+            CoroutineScope(Dispatchers.IO).launch {
+                currentUser?.delete()?.addOnSuccessListener {
+                    Log.d("JoinDuplicateFragment", "deleteCurrentUser: 인증 정보 삭제 성공")
+                }
+            }
 
             // popBackStack에서 name값을 null로 넣어주면 기존의 backstack을 모두 없애준다.
             parentFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinViewModel.kt
@@ -1,5 +1,6 @@
 package kr.co.lion.modigm.ui.join.vm
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
@@ -7,6 +8,8 @@ import com.google.firebase.auth.FirebaseAuthException
 import com.google.firebase.auth.FirebaseUser
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -132,7 +135,11 @@ class JoinViewModel @Inject constructor(
     // 회원가입 이탈 시 이미 Auth에 등록되어있는 인증 정보 삭제
     fun deleteCurrentUser(){
         // 인증 정보 삭제
-        _auth.currentUser?.delete()
+        CoroutineScope(Dispatchers.IO).launch {
+            _auth.currentUser?.delete()?.addOnSuccessListener {
+                Log.d("JoinViewModel", "deleteCurrentUser: 인증 정보 삭제 성공")
+            }
+        }
     }
 
     // UserInfoData 객체 생성

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/vm/DeleteUserViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/vm/DeleteUserViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import kr.co.lion.modigm.repository.ProfileRepository
 import kr.co.lion.modigm.util.ModigmApplication.Companion.prefs
 
@@ -14,10 +16,10 @@ class DeleteUserViewModel: ViewModel() {
     private val auth = FirebaseAuth.getInstance()
 
     private val _isDeleted = MutableStateFlow(false)
-    val isDeleted: StateFlow<Boolean> = _isDeleted
+    val isDeleted = _isDeleted.asStateFlow()
 
     private val _errorMessage = MutableStateFlow<String?>(null)
-    val errorMessage: StateFlow<String?> = _errorMessage
+    val errorMessage = _errorMessage.asStateFlow()
     suspend fun resetErrorMessage() {
         _errorMessage.emit(null)
     }
@@ -27,7 +29,7 @@ class DeleteUserViewModel: ViewModel() {
             val result = profileRepository.deleteUserData(userIdx)
             result.onSuccess {
                 // 파이어베이스 인증 정보 삭제
-                auth.currentUser?.delete()
+                auth.currentUser?.delete()?.await()
                 prefs.clearAllPrefs()
                 prefs.setBoolean("autoLogin", false)
                 _isDeleted.emit(true)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #385 

## 📝작업 내용

> 원래 코드로도 파이어베이스 인증 정보는 삭제가 되긴 하는데 어제와 같이 간혹 인증 정보가 삭제되지 않고 남아있는 경우가 있었습니다.
> 회원 탈퇴 시 인증 정보 삭제를 await한 후에 탈퇴 완료 처리하도록 수정했습니다.
> lifecyclescope나 viewmodelscope를 사용하는 경우에는 해당 코루틴 스코프가 생명주기에 맞추어 종료되기 때문에 fragment나 viewmodel이 빠르게 끝나는 경우에는 인증 정보 삭제 처리가 되지 않는 것 같아 코드를 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
