### PR TITLE
[#396] feat 고객센터, 회원 신고, 스터디 신고에 연결되는 구글폼 추가 및 수정 작업

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/detail/DetailFragment.kt
@@ -49,6 +49,7 @@ import kr.co.lion.modigm.util.ModigmApplication
 import kr.co.lion.modigm.util.Skill
 import kr.co.lion.modigm.util.openWebView
 import kotlinx.coroutines.flow.collect
+import java.util.UUID
 
 class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBinding::inflate) {
 
@@ -660,7 +661,13 @@ class DetailFragment : VBBaseFragment<FragmentDetailBinding>(FragmentDetailBindi
             popupView.findViewById<TextView>(R.id.menuItem4).setOnClickListener {
                 // 신고하기 기능
                 // 고객센터 구글폼 띄우기로 수정 by ms.
-                openWebView(viewLifecycleOwner, parentFragmentManager, Links.SERVICE.url)
+                val link = StringBuilder(Links.STUDY_SERVICE.url)
+                // 신고 스터디 idx
+                link.append("&entry.1666022374=${UUID.randomUUID().toString().split("-")[4]}#${studyIdx}")
+                // 신고자 idx
+                link.append("&entry.218705015=${UUID.randomUUID().toString().split("-")[4]}#${viewModel.userData.value?.userIdx}")
+
+                openWebView(viewLifecycleOwner, parentFragmentManager, link.toString())
                 popupWindow.dismiss()
             }
         }

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -22,6 +22,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.CustomViewTarget
 import com.google.android.material.chip.Chip
+import com.google.android.play.integrity.internal.f
 import kotlinx.coroutines.launch
 import kr.co.lion.modigm.R
 import kr.co.lion.modigm.databinding.FragmentProfileBinding
@@ -33,6 +34,7 @@ import kr.co.lion.modigm.ui.profile.vm.ProfileViewModel
 import kr.co.lion.modigm.util.FragmentName
 import kr.co.lion.modigm.util.Links
 import kr.co.lion.modigm.util.ModigmApplication.Companion.prefs
+import java.util.UUID
 
 class ProfileFragment: DBBaseFragment<FragmentProfileBinding>(R.layout.fragment_profile) {
     private val profileViewModel: ProfileViewModel by viewModels()
@@ -223,16 +225,23 @@ class ProfileFragment: DBBaseFragment<FragmentProfileBinding>(R.layout.fragment_
         popupView.findViewById<TextView>(R.id.menuItem3).setOnClickListener {
             Log.d("zunione", "touched")
             // 아이템 1이 클릭되었을 때의 처리
-            openWebView(Links.SERVICE.url)
+            openWebView()
             popupWindow.dismiss()
         }
     }
 
-    private fun openWebView(url: String){
+    private fun openWebView(){
         viewLifecycleOwner.lifecycleScope.launch {
+            // 회원 신고하기 구글폼 띄우고 필요한 값 전달 by ms.
+            val link = StringBuilder(Links.USER_SERVICE.url)
+            // 신고 대상 idx
+            link.append("&entry.1881471803=${UUID.randomUUID().toString().split("-")[4]}#${userIdx}")
+            // 신고자 idx
+            link.append("&entry.759987217=${UUID.randomUUID().toString().split("-")[4]}#${prefs.getInt("currentUserIdx")}")
+
             // bundle 에 필요한 정보를 담는다
             val bundle = Bundle()
-            bundle.putString("link", url)
+            bundle.putString("link", link.toString())
 
             // 이동할 프래그먼트로 bundle을 넘긴다
             val profileWebFragment = ProfileWebFragment()

--- a/app/src/main/java/kr/co/lion/modigm/util/Links.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/Links.kt
@@ -2,6 +2,23 @@ package kr.co.lion.modigm.util
 
 enum class Links(val url:String) {
     NOTICE("https://smooth-orangutan-e69.notion.site/0ff98834d23f43269dfab13e15ee88fb?pvs=4"),
-    SERVICE("https://forms.gle/J1qcXTYDzcgB69wQ6"),
+    SERVICE("https://docs.google.com/forms/d/e/1FAIpQLSdqxQHUyBrWro9b_MUJUerrCA4tlLuHQEwQeJhaiJm3q1rvFA/viewform?usp=sf_link"),
+    USER_SERVICE("https://docs.google.com/forms/d/e/1FAIpQLSdpbl03LqV9APHx04ehsJRJUzEXSrHWCTb2HyAD4WbCGxzbKw/viewform?usp=sf_link"),
+    STUDY_SERVICE("https://docs.google.com/forms/d/e/1FAIpQLSdr9AuE2vrGMpQTxmdo7jUYZCRZ5ZjggR5bswbDjqSSgYuhKg/viewform?usp=sf_link"),
     TERMS("https://smooth-orangutan-e69.notion.site/5c47ca9800114574898502f04b17595f?pvs=4"),
 }
+
+// 고객 센터
+// https://docs.google.com/forms/d/e/1FAIpQLSdqxQHUyBrWro9b_MUJUerrCA4tlLuHQEwQeJhaiJm3q1rvFA/viewform?usp=sf_link
+// 성함 : entry.2005620554
+// 이메일 : entry.1045781291
+
+// 스터디 신고
+// https://docs.google.com/forms/d/e/1FAIpQLSdr9AuE2vrGMpQTxmdo7jUYZCRZ5ZjggR5bswbDjqSSgYuhKg/viewform?usp=sf_link
+// 신고 번호1(스터디 IDX) : entry.1666022374
+// 신고 번호2(신고자 IDX) : entry.218705015
+
+// 회원 신고
+// https://docs.google.com/forms/d/e/1FAIpQLSdpbl03LqV9APHx04ehsJRJUzEXSrHWCTb2HyAD4WbCGxzbKw/viewform?usp=sf_link
+// 신고 번호1(신고 대상 IDX) : entry.1881471803
+// 신고 번호2(신고자 IDX) : entry.759987217

--- a/app/src/main/java/kr/co/lion/modigm/util/Links.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/Links.kt
@@ -7,18 +7,3 @@ enum class Links(val url:String) {
     STUDY_SERVICE("https://docs.google.com/forms/d/e/1FAIpQLSdr9AuE2vrGMpQTxmdo7jUYZCRZ5ZjggR5bswbDjqSSgYuhKg/viewform?usp=sf_link"),
     TERMS("https://smooth-orangutan-e69.notion.site/5c47ca9800114574898502f04b17595f?pvs=4"),
 }
-
-// 고객 센터
-// https://docs.google.com/forms/d/e/1FAIpQLSdqxQHUyBrWro9b_MUJUerrCA4tlLuHQEwQeJhaiJm3q1rvFA/viewform?usp=sf_link
-// 성함 : entry.2005620554
-// 이메일 : entry.1045781291
-
-// 스터디 신고
-// https://docs.google.com/forms/d/e/1FAIpQLSdr9AuE2vrGMpQTxmdo7jUYZCRZ5ZjggR5bswbDjqSSgYuhKg/viewform?usp=sf_link
-// 신고 번호1(스터디 IDX) : entry.1666022374
-// 신고 번호2(신고자 IDX) : entry.218705015
-
-// 회원 신고
-// https://docs.google.com/forms/d/e/1FAIpQLSdpbl03LqV9APHx04ehsJRJUzEXSrHWCTb2HyAD4WbCGxzbKw/viewform?usp=sf_link
-// 신고 번호1(신고 대상 IDX) : entry.1881471803
-// 신고 번호2(신고자 IDX) : entry.759987217


### PR DESCRIPTION
## #️⃣연관된 이슈

> #396 

## 📝작업 내용

> 고객센터, 회원 신고, 스터디 신고에 연결되는 구글폼 추가 및 수정 작업
> 공지사항 수정

### 스크린샷 (선택)
<table>
<tr><td>스터디 신고</td><td>회원 신고</td>
<tr>
<td width="350px"><video src="https://github.com/user-attachments/assets/08fbf814-e94f-482b-b5af-90eed78f58b9" /></td>
<td width="350px"><video src="https://github.com/user-attachments/assets/327b7ca0-e5f5-44f5-ab5d-6585511db636" /></td>
</tr>
<tr><td>고객센터</td><td>공지사항</td>
<tr>
<td><img src="https://github.com/user-attachments/assets/ba7faeb2-5b72-49f3-92d2-6cfc98cdfda7" /></td>
<td><img src="https://github.com/user-attachments/assets/75d22c96-76cf-4cd9-b02a-8d515aa155ea" /</td>
</tr>
</table>


## 💬리뷰 요구사항(선택)

> 구글폼에 숨김 문항이 없어서 idx값을 어쩔수 없이 노출시켜야하기 때문에 일부러 UUID로 랜덤값과 함께 붙여서서 신고글 번호로 보게 해놓았습니다. 
>구분 기호를 #으로 수정해놓았는데 영상이 수정 전 영상이라 언더바( _ )로 보여지는것만 참고해주시면 됩니다.
