### PR TITLE
[#399] fix 이름 전화번호 입력화면 넘어가지는 부분 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -312,7 +312,7 @@ class JoinFragment : DBBaseFragment<FragmentJoinBinding>(R.layout.fragment_join)
     private fun step2Process(){
         // 뒤로가기로 돌아왔을 때 이미 인증된 상태인 경우에는 바로 다음페이지로 넘어갈 수 있음
         // 전화번호를 변경하지 않은 경우에만 넘어갈 수 있음
-        if(viewModel.verifiedPhoneNumber.value == viewModelStep2.userPhone.value){
+        if(viewModel.verifiedPhoneNumber.value.isNotEmpty() && viewModel.verifiedPhoneNumber.value == viewModelStep2.userPhone.value){
             if(joinType==JoinType.EMAIL){
                 binding.viewPagerJoin.setCurrentItemWithDuration(3, 300)
             }else{


### PR DESCRIPTION
## #️⃣연관된 이슈

> #399 

## 📝작업 내용

> 전화번호 인증 후 다음화면에서 다시 이전 화면으로 돌아왔을때 바로 넘어갈 수 있도록 로직을 설정한 부분이 있었는데
처음 전화번호 인증 화면 진입 시 인증번호값이 공백인 것을 체크하는 것을 로직에 추가해놓지 않아서 바로 다음 화면으로 넘어가게 되었습니다.
로직 수정후 처음 전화번호 입력 화면 진입 시 제대로 유효성 체크가 되는 것을 확인했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
