### PR TITLE
[#402] bug 전화번호 인증 없이 넘어가지는 버그

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -200,4 +200,7 @@ dependencies {
     // java.time 패키지를 사용하기 위한 ThreeTen 백포트 사용
     implementation("com.jakewharton.threetenabp:threetenabp:1.3.0")
 
+    // 전화번호 인증 시 reCAPTCHA 에러가 날 경우 브라우저를 통한 인증이 필요함
+    implementation("androidx.browser:browser:1.8.0")
+
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinFragment.kt
@@ -310,6 +310,10 @@ class JoinFragment : DBBaseFragment<FragmentJoinBinding>(R.layout.fragment_join)
     }
 
     private fun step2Process(){
+        // 유효성 검사
+        val validation = viewModelStep2.validate()
+        if(!validation) return
+
         // 뒤로가기로 돌아왔을 때 이미 인증된 상태인 경우에는 바로 다음페이지로 넘어갈 수 있음
         // 전화번호를 변경하지 않은 경우에만 넘어갈 수 있음
         if(viewModel.verifiedPhoneNumber.value.isNotEmpty() && viewModel.verifiedPhoneNumber.value == viewModelStep2.userPhone.value){
@@ -321,9 +325,6 @@ class JoinFragment : DBBaseFragment<FragmentJoinBinding>(R.layout.fragment_join)
             return
         }
 
-        // 유효성 검사
-        val validation = viewModelStep2.validate()
-        if(!validation) return
         // 응답 받은 이름, 전화번호
         viewModel.setUserNameAndPhoneNumber(
             viewModelStep2.userName.value,

--- a/app/src/main/res/layout/fragment_join_step1.xml
+++ b/app/src/main/res/layout/fragment_join_step1.xml
@@ -89,7 +89,7 @@
                 android:layout_marginTop="5dp"
                 android:layout_marginLeft="15dp"
                 android:breakStrategy="simple"
-                android:text="최소 8자리 이상의 영문, 숫자, 특수문자 포함"
+                android:text="8~20자리, 영문, 숫자, 특수문자 포함 입력"
                 android:textSize="16dp"
                 android:textColor="#FF0000" />
 

--- a/app/src/main/res/layout/fragment_join_step1.xml
+++ b/app/src/main/res/layout/fragment_join_step1.xml
@@ -77,11 +77,21 @@
                     android:id="@+id/textInput_join_userPassword"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="영문, 숫자, 특수문자 포함 비밀번호 입력"
+                    android:hint="비밀번호 입력"
                     android:inputType="text|textPassword"
                     android:text="@={viewModel.userPassword}"
                     android:textSize="16dp" />
             </com.google.android.material.textfield.TextInputLayout>
+            <TextView
+                android:id="@+id/textView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
+                android:layout_marginLeft="15dp"
+                android:breakStrategy="simple"
+                android:text="최소 8자리 이상의 영문, 숫자, 특수문자 포함"
+                android:textSize="16dp"
+                android:textColor="#FF0000" />
 
             <TextView
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_join_step1.xml
+++ b/app/src/main/res/layout/fragment_join_step1.xml
@@ -77,7 +77,7 @@
                     android:id="@+id/textInput_join_userPassword"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="비밀번호 입력"
+                    android:hint="영문, 숫자, 특수문자 포함 비밀번호 입력"
                     android:inputType="text|textPassword"
                     android:text="@={viewModel.userPassword}"
                     android:textSize="16dp" />


### PR DESCRIPTION
## #️⃣연관된 이슈

> #402 

## 📝작업 내용

> 전화번호 인증 없이 다음으로 넘어가지는 오류가 있었습니다.
> 유효성 검사를 먼저 하여 빈칸에도 넘어가지 못하도록 수정했습니다.

> 비밀번호 입력 힌트를 "8~20자리, 영문, 숫자, 특수문자 포함 입력"으로 수정했습니다.

> 전화번호 인증 절차를 위한 브라우저 의존성을 추가했습니다.

## 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/dbff6df9-a5d9-4c18-989f-764449e30c22" width="250px" />

## 💬리뷰 요구사항(선택)


<img src="https://github.com/user-attachments/assets/67c595eb-2862-49a5-8c33-e888fe76c07d" width="250px" />

파이어베이스에 인증 요청 보내면 파이어베이스 서버에서 받을 때 해당 요청이 실제 앱에서 온 요청인지를 확인하기 위한 절차가 필요합니다. 
이 때 Google Play Services support나 브라우저를 통해 인증 절차가 진행되는데 
위의 에러가 나는 핸드폰은 플레이스토어가 깔려있지 않은 폰이라서 에러가 발생한 것으로 추정됩니다.
(공기계에서 구글계정 로그인이 안된 경우, 중국폰 등)

검색해보니 브라우저를 통해 인증이 진행이 되도록 의존성 추가가 필요하다고 하여 아래 의존성을 추가했습니다.
`implementation("androidx.browser:browser:1.8.0")`

https://stackoverflow.com/questions/65490555/this-request-is-missing-a-valid-app-identifier-meaning-that-neither-safetynet-c

