### PR TITLE
[Feat] #406 이메일 회원가입 시 FCM 토큰 등록

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/util/HiltModule.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/HiltModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityRetainedComponent
+import kr.co.lion.modigm.repository.LoginRepository
 
 /**
  *
@@ -21,5 +22,8 @@ object HiltModule {
 
     @Provides
     fun provideFirebaseAuth(): FirebaseAuth = FirebaseAuth.getInstance()
+
+    @Provides
+    fun provideLoginRepository(): LoginRepository = LoginRepository()
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #406

## 📝작업 내용

> SNS가입시에는 먼저 로그인 버튼 단계에서 FCM토큰 등록이 되는데
이메일 가입단계에서는 FCM토큰 등록 절차가 없었으므로 이 부분 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 토큰 등록하는 함수를 로그인 파트에서 그대로 가져왔는데 공통 함수로 빼놓는게 어떨까 싶습니다
