### PR TITLE
[#404] feature 회원가입 인증 메시지 파싱

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -203,4 +203,8 @@ dependencies {
     // 전화번호 인증 시 reCAPTCHA 에러가 날 경우 브라우저를 통한 인증이 필요함
     implementation("androidx.browser:browser:1.8.0")
 
+    // SMS Retriever
+    implementation("com.google.android.gms:play-services-auth:20.7.0")
+    implementation("com.google.android.gms:play-services-auth-api-phone:18.0.1")
+
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -204,7 +204,7 @@ dependencies {
     implementation("androidx.browser:browser:1.8.0")
 
     // SMS Retriever
-    implementation("com.google.android.gms:play-services-auth:20.7.0")
-    implementation("com.google.android.gms:play-services-auth-api-phone:18.0.1")
+    implementation("com.google.android.gms:play-services-auth:21.2.0")
+    implementation("com.google.android.gms:play-services-auth-api-phone:18.1.0")
 
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,5 +108,15 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+
+        <receiver
+            android:name=".util.SmsReceiver"
+            android:exported="true"
+            android:permission="com.google.android.gms.auth.api.phone.permission.SEND">
+            <intent-filter>
+                <action android:name="com.google.android.gms.auth.api.phone.SMS_RETRIEVED" />
+            </intent-filter>
+        </receiver>
+
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -117,6 +117,5 @@
                 <action android:name="com.google.android.gms.auth.api.phone.SMS_RETRIEVED" />
             </intent-filter>
         </receiver>
-
     </application>
 </manifest>

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/JoinStep2Fragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/JoinStep2Fragment.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Build
 import android.os.Bundle
 import android.telephony.PhoneNumberFormattingTextWatcher
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -76,6 +77,8 @@ class JoinStep2Fragment : DBBaseFragment<FragmentJoinStep2Binding>(R.layout.frag
 
             // 응답한 전화번호로 인증번호 SMS 보내기
             joinStep2ViewModel.sendCode(requireActivity())
+            // sms retriever 시작
+            startSmsReceiver()
         }
     }
 
@@ -86,8 +89,6 @@ class JoinStep2Fragment : DBBaseFragment<FragmentJoinStep2Binding>(R.layout.frag
             if(it){
                 binding.linearLayoutJoinPhoneAuth.visibility = View.VISIBLE
                 binding.textinputJoinPhoneAuth.requestFocus()
-                // sms retriever 시작
-                startSmsReceiver()
             }else{
                 binding.linearLayoutJoinPhoneAuth.visibility = View.GONE
             }
@@ -128,6 +129,7 @@ class JoinStep2Fragment : DBBaseFragment<FragmentJoinStep2Binding>(R.layout.frag
             }
 
             task.addOnFailureListener {
+                Log.d("startSmsReceiver", "Failure")
                 stopSmsReceiver()
             }
         }

--- a/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/join/vm/JoinStep2ViewModel.kt
@@ -192,7 +192,7 @@ class JoinStep2ViewModel @Inject constructor(
     }
 
     // 전화 인증 발송
-    fun sendCode(activity: Activity){
+    fun sendCode(activity: Activity, startSmsReceiver: ()->Unit){
         // 전화 인증 여부를 초기화
         _isVerifiedPhone.value = false
         _authExpired.value = false
@@ -209,6 +209,7 @@ class JoinStep2ViewModel @Inject constructor(
             .setCallbacks(callbacks) // OnVerificationStateChangedCallbacks
             .build()
         PhoneAuthProvider.verifyPhoneNumber(options)
+        startSmsReceiver()
     }
 
     // 전화 인증코드 발송 콜백

--- a/app/src/main/java/kr/co/lion/modigm/util/SmsReceiver.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/SmsReceiver.kt
@@ -1,0 +1,60 @@
+package kr.co.lion.modigm.util
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import android.provider.Telephony
+import android.util.Log
+import com.google.android.gms.auth.api.phone.SmsRetriever
+import com.google.android.gms.common.api.CommonStatusCodes
+import com.google.android.gms.common.api.Status
+
+class SmsReceiver: BroadcastReceiver() {
+
+    companion object {
+        private const val PATTERN = "^modigm-4afde\\.firebaseapp\\.com"
+    }
+
+    interface SmsReceiverListener {
+        fun onMessageReceived(message: String)
+    }
+
+    private var smsListener: SmsReceiverListener? = null
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if(intent?.action == Telephony.Sms.Intents.SMS_RECEIVED_ACTION) {
+            intent.extras?.let { bundle ->
+                val status = if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU){
+                    bundle.getParcelable(SmsRetriever.EXTRA_STATUS, Status::class.java) as Status
+                }else{
+                    bundle.get(SmsRetriever.EXTRA_STATUS) as Status
+                }
+
+                when(status.statusCode) {
+                    CommonStatusCodes.SUCCESS -> {
+                        // 받아온 문자 내용
+                        val sms = bundle.getString(SmsRetriever.EXTRA_SMS_MESSAGE, "")
+                        if(smsListener != null && sms.isNotEmpty()){
+                            val check = PATTERN.toRegex().find(sms)?.destructured?.component1()
+                            if(!check.isNullOrEmpty()){
+                                Log.d("test1234", "$check")
+                                smsListener!!.onMessageReceived(check)
+                            }
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+
+    fun setListener(listener: SmsReceiverListener) {
+        this.smsListener = listener
+    }
+
+    fun doFilter() = IntentFilter().apply {
+        addAction(SmsRetriever.SMS_RETRIEVED_ACTION)
+    }
+}

--- a/app/src/main/java/kr/co/lion/modigm/util/SmsReceiver.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/SmsReceiver.kt
@@ -5,8 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
-import android.provider.Telephony
-import android.util.Log
 import com.google.android.gms.auth.api.phone.SmsRetriever
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.common.api.Status
@@ -14,7 +12,7 @@ import com.google.android.gms.common.api.Status
 class SmsReceiver: BroadcastReceiver() {
 
     companion object {
-        private const val PATTERN = "^modigm-4afde\\.firebaseapp\\.com"
+        private const val PATTERN = "\\d{6}"
     }
 
     interface SmsReceiverListener {
@@ -24,24 +22,21 @@ class SmsReceiver: BroadcastReceiver() {
     private var smsListener: SmsReceiverListener? = null
 
     override fun onReceive(context: Context?, intent: Intent?) {
-        if(intent?.action == Telephony.Sms.Intents.SMS_RECEIVED_ACTION) {
+
+        if(intent?.action == SmsRetriever.SMS_RETRIEVED_ACTION) {
             intent.extras?.let { bundle ->
                 val status = if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU){
                     bundle.getParcelable(SmsRetriever.EXTRA_STATUS, Status::class.java) as Status
                 }else{
                     bundle.get(SmsRetriever.EXTRA_STATUS) as Status
                 }
-
                 when(status.statusCode) {
                     CommonStatusCodes.SUCCESS -> {
                         // 받아온 문자 내용
                         val sms = bundle.getString(SmsRetriever.EXTRA_SMS_MESSAGE, "")
-                        if(smsListener != null && sms.isNotEmpty()){
-                            val check = PATTERN.toRegex().find(sms)?.destructured?.component1()
-                            if(!check.isNullOrEmpty()){
-                                Log.d("test1234", "$check")
-                                smsListener!!.onMessageReceived(check)
-                            }
+                        val authCode = getAuthCode(sms)
+                        if(smsListener != null && authCode != null){
+                            smsListener!!.onMessageReceived(authCode)
                         }
                     }
                 }
@@ -57,4 +52,6 @@ class SmsReceiver: BroadcastReceiver() {
     fun doFilter() = IntentFilter().apply {
         addAction(SmsRetriever.SMS_RETRIEVED_ACTION)
     }
+
+    private fun getAuthCode(message: String): String? = PATTERN.toRegex().find(message)?.destructured?.component1()
 }

--- a/app/src/main/java/kr/co/lion/modigm/util/SmsReceiver.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/SmsReceiver.kt
@@ -11,13 +11,16 @@ import com.google.android.gms.common.api.Status
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class SmsReceiver: BroadcastReceiver() {
 
     companion object {
         private const val PATTERN = "\\d{6}"
-        val smsCode = MutableStateFlow("")
+
+        private val _smsCode = MutableStateFlow("")
+        val smsCode = _smsCode.asStateFlow()
     }
 
     override fun onReceive(context: Context?, intent: Intent?) {
@@ -35,7 +38,7 @@ class SmsReceiver: BroadcastReceiver() {
                         val authCode = getAuthCode(sms)
                         CoroutineScope(Dispatchers.Main).launch {
                             authCode?.let {
-                                smsCode.emit(it)
+                                _smsCode.emit(it)
                             }
                         }
                     }

--- a/app/src/main/java/kr/co/lion/modigm/util/SmsReceiver.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/SmsReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
+import android.util.Log
 import com.google.android.gms.auth.api.phone.SmsRetriever
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.common.api.Status
@@ -35,7 +36,9 @@ class SmsReceiver: BroadcastReceiver() {
                         // 받아온 문자 내용
                         val sms = bundle.getString(SmsRetriever.EXTRA_SMS_MESSAGE, "")
                         val authCode = getAuthCode(sms)
+                        Log.d("test1234", "onReceive1 : $authCode")
                         if(smsListener != null && authCode != null){
+                            Log.d("test1234", "onReceive2 : $authCode")
                             smsListener!!.onMessageReceived(authCode)
                         }
                     }
@@ -53,5 +56,5 @@ class SmsReceiver: BroadcastReceiver() {
         addAction(SmsRetriever.SMS_RETRIEVED_ACTION)
     }
 
-    private fun getAuthCode(message: String): String? = PATTERN.toRegex().find(message)?.destructured?.component1()
+    private fun getAuthCode(message: String): String? = PATTERN.toRegex().find(message)?.value
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #404 

## 📝작업 내용

> 인증 메시지 발송 후 브로드캐스트 리시버에서 문자 내용을 파싱하여 인증 번호 입력창에 붙여줍니다.

### 스크린샷 (선택)

https://github.com/user-attachments/assets/dd375a85-6f1e-44bd-b3c4-3e2a7a6bcfb0


## 💬리뷰 요구사항(선택)

> 구글링으로 검색하여 나오는 예제들이 여기서는 안먹히네요... 첫 커밋이 구글링으로 나온 예제를 그대로 프로젝트에 적용한겁니다.
예제에서는 Fragment나 Activity에서 인터페이스를 구현한 객체를 브로드캐스트 리시버에 onReceive 시점에 전달하는 것 같은데 전달한 객체가 아무리 테스트를 해도 null로 떠서... 그냥 Companion Object에 MutableStateFlow를 하나 만들고 그 값을 collecting하는 걸로 대체했습니다. 코드 보시고 누락되었다든지 잘못된 부분이 있다면 말씀 부탁드리겠습니다.