### PR TITLE
[#420] [Refactor] 소셜로그인 버튼 애니메이션 적용

### DIFF
--- a/app/src/main/java/kr/co/lion/modigm/ui/login/social/component/EmailLoginButton.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/login/social/component/EmailLoginButton.kt
@@ -1,5 +1,8 @@
 package kr.co.lion.modigm.ui.login.social.component
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -10,9 +13,15 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -23,7 +32,16 @@ import kr.co.lion.modigm.R
 @Composable
 fun EmailLoginButton(
     modifier: Modifier = Modifier,
-    onClick: () -> Unit) {
+    onClick: () -> Unit
+) {
+    var isPressed by remember { mutableStateOf(false) }
+
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.95f else 1f,
+        animationSpec = tween(durationMillis = 100),
+        label = ""
+    )
+
     Column(
         modifier = modifier
             .fillMaxSize(),
@@ -34,14 +52,32 @@ fun EmailLoginButton(
             modifier = modifier
                 .wrapContentWidth()
                 .wrapContentHeight()
-                .padding(top = 20.dp),
+                .padding(top = 20.dp)
+                .graphicsLayer(
+                    scaleX = scale,
+                    scaleY = scale
+                ),
             colors = ButtonDefaults.textButtonColors(
                 contentColor = Color.White
             ),
             shape = RoundedCornerShape(0.dp),
         ) {
             Text(
-                text = "다른 방법으로 로그인",
+                modifier = modifier
+                    .pointerInput(Unit) {
+                        detectTapGestures(
+                            onPress = {
+                                isPressed = true
+                                tryAwaitRelease()
+                                isPressed = false
+                            },
+                            onTap = {
+                                isPressed = false
+                                onClick()
+                            }
+                        )
+                    },
+                text = "이메일로 로그인",
                 fontSize = 16.sp,
                 fontFamily = FontFamily(Font(R.font.one_mobile_pop_otf)),
                 fontWeight = FontWeight.Normal,

--- a/app/src/main/java/kr/co/lion/modigm/ui/login/social/component/GithubLoginButton.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/login/social/component/GithubLoginButton.kt
@@ -1,5 +1,8 @@
 package kr.co.lion.modigm.ui.login.social.component
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,22 +17,43 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kr.co.lion.modigm.R
 
 @Composable
-fun GithubLoginButton(onClick: () -> Unit) {
+fun GithubLoginButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    var isPressed by remember { mutableStateOf(false) }
+
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.95f else 1f,
+        animationSpec = tween(durationMillis = 100),
+        label = ""
+    )
+
     Button(
         onClick = onClick,
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(top = 30.dp)
-            .height(48.dp),
+            .height(48.dp)
+            .graphicsLayer(
+                scaleX = scale,
+                scaleY = scale
+            ),
         colors = ButtonDefaults.buttonColors(
             containerColor = Color.Black,
             contentColor = Color.White
@@ -38,14 +62,27 @@ fun GithubLoginButton(onClick: () -> Unit) {
         contentPadding = PaddingValues(0.dp),
     ) {
         Box(
-            modifier = Modifier
+            modifier = modifier
                 .fillMaxSize()
                 .padding(horizontal = 16.dp)
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onPress = {
+                            isPressed = true
+                            tryAwaitRelease()
+                            isPressed = false
+                        },
+                        onTap = {
+                            isPressed = false
+                            onClick()
+                        }
+                    )
+                },
         ) {
             Icon(
                 painter = painterResource(id = R.drawable.icon_github_logo),
                 contentDescription = "깃허브 로고",
-                modifier = Modifier
+                modifier = modifier
                     .size(24.dp)
                     .align(Alignment.CenterStart),
                 tint = Color.White
@@ -54,7 +91,7 @@ fun GithubLoginButton(onClick: () -> Unit) {
                 text = "깃허브 로그인",
                 fontSize = 20.sp,
                 color = Color.White,
-                modifier = Modifier
+                modifier = modifier
                     .align(Alignment.Center)
                     .offset(x = 12.dp)
             )

--- a/app/src/main/java/kr/co/lion/modigm/ui/login/social/component/KakaoLoginButton.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/login/social/component/KakaoLoginButton.kt
@@ -1,6 +1,9 @@
 package kr.co.lion.modigm.ui.login.social.component
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -9,8 +12,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -21,11 +30,23 @@ fun KakaoLoginButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
+    var isPressed by remember { mutableStateOf(false) }
+
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.95f else 1f,
+        animationSpec = tween(durationMillis = 100),
+        label = ""
+    )
+
     Button(
         onClick = onClick,
         modifier = modifier
             .fillMaxWidth()
-            .padding(top = 40.dp),
+            .padding(top = 40.dp)
+            .graphicsLayer(
+                scaleX = scale,
+                scaleY = scale
+            ),
         colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
         contentPadding = PaddingValues(0.dp),
         shape = RoundedCornerShape(0.dp),
@@ -35,7 +56,20 @@ fun KakaoLoginButton(
             contentDescription = "카카오 로그인",
             modifier = modifier
                 .fillMaxWidth()
-                .height(48.dp),
+                .height(48.dp)
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onPress = {
+                            isPressed = true
+                            tryAwaitRelease()
+                            isPressed = false
+                        },
+                        onTap = {
+                            isPressed = false
+                            onClick()
+                        }
+                    )
+                },
             contentScale = ContentScale.FillBounds
         )
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

#420

## 📝작업 내용

소셜로그인 버튼에 애니메이션 적용했습니다!

### 스크린샷
[2025_01_02_소셜로그인_버튼_애니메니션.webm](https://github.com/user-attachments/assets/d9174e73-bb6c-4d79-a804-d05ee5b8f770)
## 💬리뷰 요구사항
[2025_01_02_이메일로그인으로_이동_버튼_애니메니션.webm](https://github.com/user-attachments/assets/12711968-1af6-47d0-8b5e-99017472d754)

위 영상 처럼 애니메이션을 '이메일로 로그인' 텍스트 버튼에도 적용해야할 지 고민이네요 ㅎㅎ 티는 별로 안나는데 버튼이라서 적용은 해놨습니다. 그대로 두는 게 나을까요??