### PR TITLE
#423 refactor 프로필 화면 jetpack compose 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -152,6 +152,7 @@ dependencies {
     // Glide
     implementation("com.github.bumptech.glide:glide:4.16.0")
     implementation("jp.wasabeef:glide-transformations:4.3.0")
+    implementation("com.github.bumptech.glide:compose:1.0.0-alpha.1")
 
     // 원형 이미지 라이브러리
     implementation("de.hdodenhof:circleimageview:3.1.0")

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -5,9 +5,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -27,6 +29,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
@@ -137,7 +140,8 @@ class ProfileFragment : Fragment() {
             Image(
                 painter = painterResource(id = R.drawable.image_loading_gray),
                 contentDescription = "Profile Picture",
-                modifier = Modifier.size(100.dp)
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.size(100.dp).clip(CircleShape)
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(text = name, fontSize = 18.sp, fontWeight = FontWeight.Bold)

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -103,9 +104,11 @@ class ProfileFragment : Fragment() {
         val profilePartStudies by viewModel.profilePartStudyList.collectAsState(initial = emptyList())
 
         Scaffold(
+            modifier = Modifier.background(Color.White),
             topBar = {
                 TopAppBar(
                     title = { Text(text = "프로필") },
+                    colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White),
                     actions = {
                         IconButton(onClick = { /* TODO: Handle settings */ }) {
                             Icon(painterResource(id = R.drawable.icon_settings_24px), contentDescription = "Settings")
@@ -118,6 +121,7 @@ class ProfileFragment : Fragment() {
                 modifier = Modifier
                     .padding(paddingValues)
                     .fillMaxSize()
+                    .background(Color.White)
                     .verticalScroll(rememberScrollState())
                     .padding(16.dp)
             ) {

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -52,6 +52,7 @@ import kr.co.lion.modigm.R
 import kr.co.lion.modigm.model.StudyData
 import kr.co.lion.modigm.ui.detail.DetailFragment
 import kr.co.lion.modigm.ui.profile.vm.ProfileViewModel
+import kr.co.lion.modigm.ui.theme.ModigmTheme
 import kr.co.lion.modigm.util.CustomColor
 import kr.co.lion.modigm.util.FragmentName
 import java.net.URL
@@ -83,7 +84,9 @@ class ProfileFragment : Fragment() {
 
         return ComposeView(requireContext()).apply {
             setContent {
-                ProfileScreen(viewModel = viewModel)
+                ModigmTheme {
+                    ProfileScreen(viewModel = viewModel)
+                }
             }
         }
     }
@@ -104,9 +107,9 @@ class ProfileFragment : Fragment() {
         val profilePartStudies by viewModel.profilePartStudyList.collectAsState(initial = emptyList())
 
         Scaffold(
-            modifier = Modifier.background(Color.White),
             topBar = {
                 TopAppBar(
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 10.dp),
                     title = { Text(text = "프로필") },
                     colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White),
                     actions = {
@@ -145,7 +148,9 @@ class ProfileFragment : Fragment() {
                 painter = painterResource(id = R.drawable.image_loading_gray),
                 contentDescription = "Profile Picture",
                 contentScale = ContentScale.Crop,
-                modifier = Modifier.size(100.dp).clip(CircleShape)
+                modifier = Modifier
+                    .size(100.dp)
+                    .clip(CircleShape)
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(text = name, fontSize = 18.sp, fontWeight = FontWeight.Bold)
@@ -185,24 +190,32 @@ class ProfileFragment : Fragment() {
                     Image(
                         painter = painterResource(id = iconRes),
                         contentDescription = "$domain icon",
-                        modifier = Modifier.size(30.dp).padding(end = 8.dp).clickable {
-                            viewLifecycleOwner.lifecycleScope.launch {
-                                // bundle 에 필요한 정보를 담는다
-                                val bundle = Bundle()
-                                bundle.putString("link", link)
+                        modifier = Modifier
+                            .size(30.dp)
+                            .padding(end = 8.dp)
+                            .clickable {
+                                viewLifecycleOwner.lifecycleScope.launch {
+                                    // bundle 에 필요한 정보를 담는다
+                                    val bundle = Bundle()
+                                    bundle.putString("link", link)
 
-                                // 이동할 프래그먼트로 bundle을 넘긴다
-                                val profileWebFragment = ProfileWebFragment()
-                                profileWebFragment.arguments = bundle
+                                    // 이동할 프래그먼트로 bundle을 넘긴다
+                                    val profileWebFragment = ProfileWebFragment()
+                                    profileWebFragment.arguments = bundle
 
-                                // Fragment 교체
-                                requireActivity().supportFragmentManager.commit {
-                                    setCustomAnimations(R.anim.slide_in, R.anim.fade_out, R.anim.fade_in, R.anim.slide_out)
-                                    replace(R.id.containerMain, profileWebFragment)
-                                    addToBackStack(FragmentName.PROFILE_WEB.str)
+                                    // Fragment 교체
+                                    requireActivity().supportFragmentManager.commit {
+                                        setCustomAnimations(
+                                            R.anim.slide_in,
+                                            R.anim.fade_out,
+                                            R.anim.fade_in,
+                                            R.anim.slide_out
+                                        )
+                                        replace(R.id.containerMain, profileWebFragment)
+                                        addToBackStack(FragmentName.PROFILE_WEB.str)
+                                    }
                                 }
                             }
-                        }
                     )
                 }
             }
@@ -234,24 +247,32 @@ class ProfileFragment : Fragment() {
     @OptIn(ExperimentalGlideComposeApi::class)
     @Composable
     fun StudyItem(study: StudyData) {
-        Row(modifier = Modifier.fillMaxWidth().padding(8.dp).clickable {
-            viewLifecycleOwner.lifecycleScope.launch {
-                val detailFragment = DetailFragment()
+        Row(modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .clickable {
+                viewLifecycleOwner.lifecycleScope.launch {
+                    val detailFragment = DetailFragment()
 
-                // Bundle 생성 및 현재 사용자 uid 담기
-                val bundle = Bundle()
-                bundle.putInt("studyIdx", study.studyIdx)
+                    // Bundle 생성 및 현재 사용자 uid 담기
+                    val bundle = Bundle()
+                    bundle.putInt("studyIdx", study.studyIdx)
 
-                // Bundle을 ProfileFragment에 설정
-                detailFragment.arguments = bundle
+                    // Bundle을 ProfileFragment에 설정
+                    detailFragment.arguments = bundle
 
-                requireActivity().supportFragmentManager.commit {
-                    setCustomAnimations(R.anim.slide_in, R.anim.fade_out, R.anim.fade_in, R.anim.slide_out)
-                    replace(R.id.containerMain, detailFragment)
-                    addToBackStack(FragmentName.DETAIL.str)
+                    requireActivity().supportFragmentManager.commit {
+                        setCustomAnimations(
+                            R.anim.slide_in,
+                            R.anim.fade_out,
+                            R.anim.fade_in,
+                            R.anim.slide_out
+                        )
+                        replace(R.id.containerMain, detailFragment)
+                        addToBackStack(FragmentName.DETAIL.str)
+                    }
                 }
-            }
-        }) {
+            }) {
             Card(
                 shape = RoundedCornerShape(8.dp),
                 modifier = Modifier.size(70.dp)

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -126,7 +126,8 @@ class ProfileFragment : Fragment() {
                     .fillMaxSize()
                     .background(Color.White)
                     .verticalScroll(rememberScrollState())
-                    .padding(16.dp)
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 ProfileHeader(name = profileName ?: "Default Name", intro = profileIntro ?: "Default Intro")
                 Spacer(modifier = Modifier.height(16.dp))
@@ -162,7 +163,7 @@ class ProfileFragment : Fragment() {
     @OptIn(ExperimentalLayoutApi::class)
     @Composable
     fun InterestsSection(interests: String) {
-        Column {
+        Column(modifier = Modifier.fillMaxWidth()) {
             Text(text = "관심분야", fontSize = 16.sp, fontWeight = FontWeight.Bold)
             Spacer(modifier = Modifier.height(8.dp))
             FlowRow {

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -1,142 +1,87 @@
 package kr.co.lion.modigm.ui.profile
 
-import android.graphics.drawable.Drawable
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.LinearLayout
-import android.widget.PopupWindow
-import android.widget.TextView
-import androidx.appcompat.content.res.AppCompatResources
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
-import com.bumptech.glide.request.RequestOptions
-import com.bumptech.glide.request.target.CustomViewTarget
-import com.google.android.material.chip.Chip
-import com.google.android.play.integrity.internal.f
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
 import kotlinx.coroutines.launch
 import kr.co.lion.modigm.R
-import kr.co.lion.modigm.databinding.FragmentProfileBinding
-import kr.co.lion.modigm.ui.DBBaseFragment
+import kr.co.lion.modigm.model.StudyData
 import kr.co.lion.modigm.ui.detail.DetailFragment
-import kr.co.lion.modigm.ui.profile.adapter.LinkAdapter
-import kr.co.lion.modigm.ui.profile.adapter.ProfileStudyAdapter
 import kr.co.lion.modigm.ui.profile.vm.ProfileViewModel
+import kr.co.lion.modigm.util.CustomColor
 import kr.co.lion.modigm.util.FragmentName
-import kr.co.lion.modigm.util.Links
-import kr.co.lion.modigm.util.ModigmApplication.Companion.prefs
-import java.util.UUID
+import java.net.URL
 
-class ProfileFragment: DBBaseFragment<FragmentProfileBinding>(R.layout.fragment_profile) {
-    private val profileViewModel: ProfileViewModel by viewModels()
+class ProfileFragment : Fragment() {
+
+    private val viewModel: ProfileViewModel by viewModels()
 
     // onCreateView에서 초기화
     var userIdx: Int? = null
     var isBottomNavi: Boolean? = null
 
-    // 어댑터 선언
-    val linkAdapter: LinkAdapter = LinkAdapter(
-        // 빈 리스트를 넣어 초기화
-        emptyList(),
-
-        // 항목을 클릭: Url을 받아온다
-        rowClickListener = { linkUrl ->
-            Log.d("테스트 rowClickListener deliveryIdx", linkUrl)
-            viewLifecycleOwner.lifecycleScope.launch {
-                // bundle 에 필요한 정보를 담는다
-                val bundle = Bundle()
-                bundle.putString("link", linkUrl)
-
-                // 이동할 프래그먼트로 bundle을 넘긴다
-                val profileWebFragment = ProfileWebFragment()
-                profileWebFragment.arguments = bundle
-
-                // Fragment 교체
-                requireActivity().supportFragmentManager.commit {
-                    setCustomAnimations(R.anim.slide_in, R.anim.fade_out, R.anim.fade_in, R.anim.slide_out)
-                    replace(R.id.containerMain, profileWebFragment)
-                    addToBackStack(FragmentName.PROFILE_WEB.str)
-                }
-            }
-        }
-    )
-
-    val partStudyAdapter: ProfileStudyAdapter = ProfileStudyAdapter(
-        // 빈 리스트를 넣어 초기화
-        emptyList(),
-
-        // 항목을 클릭: 스터디 고유번호를 이용하여 해당 스터디 화면으로 이동한다
-        rowClickListener = { studyIdx ->
-            viewLifecycleOwner.lifecycleScope.launch {
-                val detailFragment = DetailFragment()
-
-                // Bundle 생성 및 현재 사용자 uid 담기
-                val bundle = Bundle()
-                Log.d("zunione", "$studyIdx")
-                bundle.putInt("studyIdx", studyIdx)
-
-                // Bundle을 ProfileFragment에 설정
-                detailFragment.arguments = bundle
-
-                requireActivity().supportFragmentManager.commit {
-                    setCustomAnimations(R.anim.slide_in, R.anim.fade_out, R.anim.fade_in, R.anim.slide_out)
-                    replace(R.id.containerMain, detailFragment)
-                    addToBackStack(FragmentName.DETAIL.str)
-                }
-            }
-        }
-    )
-
-    val hostStudyAdapter: ProfileStudyAdapter = ProfileStudyAdapter(
-        // 빈 리스트를 넣어 초기화
-        emptyList(),
-
-        // 항목을 클릭: 스터디 고유번호를 이용하여 해당 스터디 화면으로 이동한다
-        rowClickListener = { studyIdx ->
-            viewLifecycleOwner.lifecycleScope.launch {
-                val detailFragment = DetailFragment()
-
-                // Bundle 생성 및 현재 사용자 uid 담기
-                val bundle = Bundle()
-                Log.d("zunione", "$studyIdx")
-                bundle.putInt("studyIdx", studyIdx)
-
-                // Bundle을 ProfileFragment에 설정
-                detailFragment.arguments = bundle
-
-                requireActivity().supportFragmentManager.commit {
-                    setCustomAnimations(R.anim.slide_in, R.anim.fade_out, R.anim.fade_in, R.anim.slide_out)
-                    replace(R.id.containerMain, detailFragment)
-                    addToBackStack(FragmentName.DETAIL.str)
-                }
-            }
-        }
+    private val domainIcons = mapOf(
+        "youtube.com" to R.drawable.icon_youtube_logo,
+        "github.com" to R.drawable.icon_github_logo,
+        "linkedin.com" to R.drawable.icon_linkedin_logo,
+        "velog.io" to R.drawable.icon_velog_logo,
+        "instagram.com" to R.drawable.icon_instagram_logo,
+        "notion.com" to R.drawable.icon_notion_logo,
+        "facebook.com" to R.drawable.icon_facebook_logo,
+        "twitter.com" to R.drawable.icon_twitter_logo,
+        "open.kakao.com" to R.drawable.kakaotalk_sharing_btn_small,
+        "default" to R.drawable.icon_link
     )
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        super.onCreateView(inflater, container, savedInstanceState)
-        // Bind ViewModel and lifecycle owner
-        binding.profileViewModel = profileViewModel
-        binding.lifecycleOwner = this.viewLifecycleOwner
-
         userIdx = arguments?.getInt("userIdx")
         isBottomNavi = arguments?.getBoolean("isBottomNavi")
 
-        return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        initView()
+        return ComposeView(requireContext()).apply {
+            setContent {
+                ProfileScreen(viewModel = viewModel)
+            }
+        }
     }
 
     override fun onResume() {
@@ -144,335 +89,235 @@ class ProfileFragment: DBBaseFragment<FragmentProfileBinding>(R.layout.fragment_
         setupUserInfo()
     }
 
-    private fun initView() {
-        setupToolbar()
-        setupRecyclerViewLink()
-        setupRecyclerViewPartStudy()
-        setupRecyclerViewHostStudy()
-        setupIconMoreStudy()
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    fun ProfileScreen(viewModel: ProfileViewModel = viewModel()) {
+        val profileName by viewModel.profileName.collectAsState(initial = "")
+        val profileIntro by viewModel.profileIntro.collectAsState(initial = "")
+        val profileInterests by viewModel.profileInterests.collectAsState(initial = "")
+        val profileLinks by viewModel.profileLinkList.collectAsState(initial = emptyList())
+        val profileHostStudies by viewModel.profileHostStudyList.collectAsState(initial = emptyList())
+        val profilePartStudies by viewModel.profilePartStudyList.collectAsState(initial = emptyList())
 
-        observeData()
-    }
-
-    private fun setupToolbar() {
-        binding.toolbarProfile.apply {
-            // 툴바 메뉴
-            inflateMenu(R.menu.menu_profile)
-            setOnMenuItemClickListener {
-                when (it.itemId) {
-                    R.id.menu_item_profile_setting -> {
-                        requireActivity().supportFragmentManager.commit {
-                            setCustomAnimations(R.anim.slide_in, R.anim.fade_out, R.anim.fade_in, R.anim.slide_out)
-                            replace(R.id.containerMain, SettingsFragment())
-                            addToBackStack(FragmentName.SETTINGS.str)
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text(text = "프로필") },
+                    actions = {
+                        IconButton(onClick = { /* TODO: Handle settings */ }) {
+                            Icon(painterResource(id = R.drawable.icon_settings_24px), contentDescription = "Settings")
                         }
                     }
+                )
+            }
+        ) { paddingValues ->
+            Column(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp)
+            ) {
+                ProfileHeader(name = profileName ?: "Default Name", intro = profileIntro ?: "Default Intro")
+                Spacer(modifier = Modifier.height(16.dp))
+                InterestsSection(profileInterests ?: "")
+                Spacer(modifier = Modifier.height(16.dp))
+                LinksSection(profileLinks)
+                Spacer(modifier = Modifier.height(16.dp))
+                StudiesSection("진행한 스터디", profileHostStudies)
+                Spacer(modifier = Modifier.height(16.dp))
+                StudiesSection("참여한 스터디", profilePartStudies)
+            }
+        }
+    }
 
-                    R.id.menu_item_profile_more -> {
-                        showDropdownReport(this.findViewById(R.id.menu_item_profile_more))
+    @Composable
+    fun ProfileHeader(name: String, intro: String) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Image(
+                painter = painterResource(id = R.drawable.image_loading_gray),
+                contentDescription = "Profile Picture",
+                modifier = Modifier.size(100.dp)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = name, fontSize = 18.sp, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(text = intro, fontSize = 14.sp, color = CustomColor.TEXTGRAY)
+        }
+    }
+
+    @OptIn(ExperimentalLayoutApi::class)
+    @Composable
+    fun InterestsSection(interests: String) {
+        Column {
+            Text(text = "관심분야", fontSize = 16.sp, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(8.dp))
+            FlowRow {
+                interests.split(",").forEach { interest ->
+                    SuggestionChip(onClick = { /*TODO*/ }, label = { Text(interest) })
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun LinksSection(links: List<String>) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Text(text = "링크", fontSize = 16.sp, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(8.dp))
+            links.forEach { link ->
+                Row(
+                    modifier = Modifier
+                        .padding(vertical = 4.dp)
+                        .fillMaxWidth()
+                ) {
+                    val domain = extractDomain(link)
+                    val iconRes = domainIcons[domain] ?: R.drawable.icon_link
+
+                    Image(
+                        painter = painterResource(id = iconRes),
+                        contentDescription = "$domain icon",
+                        modifier = Modifier.size(30.dp).padding(end = 8.dp).clickable {
+                            viewLifecycleOwner.lifecycleScope.launch {
+                                // bundle 에 필요한 정보를 담는다
+                                val bundle = Bundle()
+                                bundle.putString("link", link)
+
+                                // 이동할 프래그먼트로 bundle을 넘긴다
+                                val profileWebFragment = ProfileWebFragment()
+                                profileWebFragment.arguments = bundle
+
+                                // Fragment 교체
+                                requireActivity().supportFragmentManager.commit {
+                                    setCustomAnimations(R.anim.slide_in, R.anim.fade_out, R.anim.fade_in, R.anim.slide_out)
+                                    replace(R.id.containerMain, profileWebFragment)
+                                    addToBackStack(FragmentName.PROFILE_WEB.str)
+                                }
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun StudiesSection(title: String, studies: List<StudyData>?) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Text(text = title, fontSize = 18.sp, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(8.dp))
+            if (studies.isNullOrEmpty()) {
+                Text(
+                    text = "데이터가 없습니다",
+                    fontSize = 16.sp,
+                    modifier = Modifier.padding(16.dp)
+                )
+            } else {
+                Column {
+                    studies.forEach { study ->
+                        StudyItem(study)
+                        HorizontalDivider(thickness = 0.5.dp, color = Color.LightGray)
                     }
                 }
-                true
             }
+        }
+    }
 
-            // 모든 메뉴를 보이지 않는 상태로 둔다.
-            // 사용자 정보를 가져온 다음 메뉴를 노출 시킨다.
-            menu.findItem(R.id.menu_item_profile_setting).isVisible = false
-            menu.findItem(R.id.menu_item_profile_more).isVisible = false
+    @OptIn(ExperimentalGlideComposeApi::class)
+    @Composable
+    fun StudyItem(study: StudyData) {
+        Row(modifier = Modifier.fillMaxWidth().padding(8.dp).clickable {
+            viewLifecycleOwner.lifecycleScope.launch {
+                val detailFragment = DetailFragment()
 
-            // BottomNavigation 으로 접근했을 때: 설정 아이콘
-            if (isBottomNavi == true) {
-                // 설정 아이콘 표시
-                menu.findItem(R.id.menu_item_profile_setting).isVisible = true
-            } else {
-                // 스터디 상세 화면의 프로필로 접근했을 때: 뒤로 가기, 더보기 아이콘
-                // 뒤로 가기
-                setNavigationIcon(R.drawable.icon_arrow_back_24px)
-                setNavigationOnClickListener {
-                    parentFragmentManager.popBackStack()
+                // Bundle 생성 및 현재 사용자 uid 담기
+                val bundle = Bundle()
+                bundle.putInt("studyIdx", study.studyIdx)
+
+                // Bundle을 ProfileFragment에 설정
+                detailFragment.arguments = bundle
+
+                requireActivity().supportFragmentManager.commit {
+                    setCustomAnimations(R.anim.slide_in, R.anim.fade_out, R.anim.fade_in, R.anim.slide_out)
+                    replace(R.id.containerMain, detailFragment)
+                    addToBackStack(FragmentName.DETAIL.str)
                 }
+            }
+        }) {
+            Card(
+                shape = RoundedCornerShape(8.dp),
+                modifier = Modifier.size(70.dp)
+            ) {
+                GlideImage(
+                    model = study.studyPic,
+                    contentDescription = "Study Image",
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = study.studyTitle,
+                    fontSize = 16.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.icon_category_24px),
+                        contentDescription = "Category Icon",
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(text = study.studyType, fontSize = 14.sp)
 
-                // 더보기 아이콘: 신고 기능이므로 타인의 프로필일 때만 표시
-                if (userIdx != prefs.getInt("currentUserIdx")) {
-                    menu.findItem(R.id.menu_item_profile_more).isVisible = true
+                    Spacer(modifier = Modifier.width(16.dp))
+
+                    Icon(
+                        painter = painterResource(id = R.drawable.icon_location_on_24px),
+                        contentDescription = "Location Icon",
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(text = study.studyOnOffline, fontSize = 14.sp)
+
+                    Spacer(modifier = Modifier.width(16.dp))
+
+                    Icon(
+                        painter = painterResource(id = R.drawable.icon_person_24px),
+                        contentDescription = "Member Icon",
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(text = study.studyCanApply, fontSize = 14.sp)
                 }
             }
         }
     }
 
-    private fun showDropdownReport(anchorView: View) {
-        // 팝업 윈도우의 레이아웃을 설정
-        val popupView = LayoutInflater.from(requireContext()).inflate(R.layout.custom_profile_report_dropdown, null)
-
-        // 팝업 윈도우 객체 생성
-        val popupWindow = PopupWindow(popupView, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-
-        // 배경을 설정해야 그림자가 적용됨 (반드시 배경이 있어야 함)
-        popupWindow.setBackgroundDrawable(AppCompatResources.getDrawable(requireContext(), android.R.drawable.dialog_holo_light_frame))
-
-        // 팝업 윈도우 외부를 터치하면 닫히도록 설정
-        popupWindow.isOutsideTouchable = true
-        popupWindow.isFocusable = true
-
-        // 팝업 윈도우를 anchorView 아래에 표시
-        popupWindow.showAsDropDown(anchorView, -200, -30)
-        popupWindow.elevation = 10f
-
-        // 팝업 안의 아이템 클릭 리스너 설정
-        val item1: LinearLayout = popupView.findViewById(R.id.layoutProfileReport)
-        item1.isClickable = true
-
-        popupView.findViewById<TextView>(R.id.menuItem3).setOnClickListener {
-            Log.d("zunione", "touched")
-            // 아이템 1이 클릭되었을 때의 처리
-            openWebView()
-            popupWindow.dismiss()
-        }
-    }
-
-    private fun openWebView(){
-        viewLifecycleOwner.lifecycleScope.launch {
-            // 회원 신고하기 구글폼 띄우고 필요한 값 전달 by ms.
-            val link = StringBuilder(Links.USER_SERVICE.url)
-            // 신고 대상 idx
-            link.append("&entry.1881471803=${UUID.randomUUID().toString().split("-")[4]}#${userIdx}")
-            // 신고자 idx
-            link.append("&entry.759987217=${UUID.randomUUID().toString().split("-")[4]}#${prefs.getInt("currentUserIdx")}")
-
-            // bundle 에 필요한 정보를 담는다
-            val bundle = Bundle()
-            bundle.putString("link", link.toString())
-
-            // 이동할 프래그먼트로 bundle을 넘긴다
-            val profileWebFragment = ProfileWebFragment()
-            profileWebFragment.arguments = bundle
-
-            // Fragment 교체
-            parentFragmentManager.commit {
-                //setCustomAnimations(R.anim.slide_in, R.anim.fade_out, R.anim.fade_in, R.anim.slide_out)
-                replace(R.id.containerMain, profileWebFragment)
-                addToBackStack(FragmentName.PROFILE_WEB.str)
-            }
-        }
+    @Preview
+    @Composable
+    fun ProfileScreenPreview() {
+        ProfileScreen()
     }
 
     private fun setupUserInfo() {
-        profileViewModel.profileUserIdx.value = userIdx
-        profileViewModel.loadUserData()
-        profileViewModel.loadUserLinkListData()
-        profileViewModel.loadHostStudyList(userIdx!!)
-        profileViewModel.loadPartStudyList(userIdx!!)
+        viewModel.profileUserIdx.value = userIdx
+        viewModel.loadUserData()
+        viewModel.loadUserLinkListData()
+        viewModel.loadHostStudyList(userIdx!!)
+        viewModel.loadPartStudyList(userIdx!!)
     }
 
-    private fun setupRecyclerViewLink() {
-        // 리사이클러뷰 구성
-        binding.recyclerVIewProfileLink.apply {
-            // 리사이클러뷰 어댑터
-            adapter = linkAdapter
-
-            // 리사이클러뷰 레이아웃
-            layoutManager = LinearLayoutManager(requireContext(), RecyclerView.HORIZONTAL, false)
-        }
-    }
-
-    private fun setupRecyclerViewPartStudy() {
-        // 리사이클러뷰 구성
-        binding.recyclerViewProfilePartStudy.apply {
-            // 리사이클러뷰 어댑터
-            adapter = partStudyAdapter
-
-            // 리사이클러뷰 레이아웃
-            layoutManager = LinearLayoutManager(requireContext())
-        }
-    }
-
-    private fun setupRecyclerViewHostStudy() {
-        // 리사이클러뷰 구성
-        binding.recyclerViewProfileHostStudy.apply {
-            // 리사이클러뷰 어댑터
-            adapter = hostStudyAdapter
-
-            // 리사이클러뷰 레이아웃
-            layoutManager = LinearLayoutManager(requireContext())
-        }
-    }
-
-    private fun setupIconMoreStudy() {
-        binding.apply {
-            layoutMoreProfileHostStudy.setOnClickListener {
-                // bundle 에 필요한 정보를 담는다
-                val bundle = Bundle()
-                bundle.putInt("type", 1)
-                bundle.putInt("userIdx", userIdx!!)
-
-                // 이동할 프래그먼트로 bundle을 넘긴다
-                val profileStudyFragment = ProfileStudyFragment()
-                profileStudyFragment.arguments = bundle
-
-                requireActivity().supportFragmentManager.commit {
-                    setCustomAnimations(R.anim.slide_in, R.anim.fade_out, R.anim.fade_in, R.anim.slide_out)
-                    replace(R.id.containerMain, profileStudyFragment)
-                    addToBackStack(FragmentName.PROFILE_STUDY.str)
-                }
-            }
-
-            layoutMoreProfilePartStudy.setOnClickListener {
-                // bundle 에 필요한 정보를 담는다
-                val bundle = Bundle()
-                bundle.putInt("type", 2)
-                bundle.putInt("userIdx", userIdx!!)
-
-                // 이동할 프래그먼트로 bundle을 넘긴다
-                val profileStudyFragment = ProfileStudyFragment()
-                profileStudyFragment.arguments = bundle
-
-                requireActivity().supportFragmentManager.commit {
-                    setCustomAnimations(R.anim.slide_in, R.anim.fade_out, R.anim.fade_in, R.anim.slide_out)
-                    replace(R.id.containerMain, profileStudyFragment)
-                    addToBackStack(FragmentName.PROFILE_STUDY.str)
-                }
-            }
-        }
-    }
-
-    // 데이터 변경 관찰
-    fun observeData() {
-        // 자기소개
-        lifecycleScope.launch {
-            profileViewModel.profileIntro.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collect { intro ->
-                if (intro.isNullOrEmpty()) {
-                    binding.textViewProfileIntro.visibility = View.GONE
-                } else {
-                    binding.textViewProfileIntro.visibility = View.VISIBLE
-                }
-
-            }
-        }
-
-        // 프로필 사진
-        lifecycleScope.launch {
-            profileViewModel.profileUserImage.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collect { image ->
-                if (!image.isNullOrEmpty()) {
-                    val requestOptions = RequestOptions()
-                        .placeholder(R.drawable.image_loading_gray) // 필요 시 기본 플레이스홀더 설정
-                        .error(R.drawable.image_detail_1) // 이미지 로딩 실패 시 표시할 이미지
-
-                    Glide.with(requireContext())
-                        .load(image)
-                        .apply(requestOptions)
-                        .into(object : CustomViewTarget<ImageView, Drawable>(binding.imageProfilePic) {
-                            override fun onLoadFailed(errorDrawable: Drawable?) {
-                                // 로딩 실패 시 기본 이미지를 보여줌
-                                binding.imageProfilePic.setImageResource(R.drawable.image_default_profile)
-                            }
-
-                            override fun onResourceCleared(placeholder: Drawable?) {
-                                // 리소스가 클리어 될 때
-                            }
-
-                            override fun onResourceReady(resource: Drawable, transition: com.bumptech.glide.request.transition.Transition<in Drawable>?) {
-                                // 로딩 성공 시
-                                binding.imageProfilePic.setImageDrawable(resource)
-                            }
-                        })
-                } else {
-                    // 등록되어 있는 이미지가 없을 때
-                    binding.imageProfilePic.setImageResource(R.drawable.image_default_profile)
-                }
-            }
-        }
-
-        // 관심 분야 chipGroup
-        lifecycleScope.launch {
-            profileViewModel.profileInterests.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collect { interests ->
-                // 기존 칩들 제거
-                binding.chipGroupProfile.removeAllViews()
-
-                // 리스트가 변경될 때마다 for 문을 사용하여 아이템을 처리
-                if (interests.isNullOrEmpty()) {
-                    binding.layoutInterestChipGroup.visibility = View.GONE
-                } else {
-                    binding.layoutInterestChipGroup.visibility = View.VISIBLE
-                    val interestList = interests.split(",").map { it.trim() }
-
-                    for (interest in interestList) {
-                        // 아이템 처리 코드
-                        binding.chipGroupProfile.addView(Chip(context).apply {
-                            text = interest
-                            setTextAppearance(R.style.ChipTextStyle)
-                            // 자동 padding 없애기
-                            setEnsureMinTouchTargetSize(false)
-                            // 배경 흰색으로 지정
-                            setChipBackgroundColorResource(android.R.color.white)
-                            // 클릭 불가
-                            isClickable = false
-                        })
-                    }
-                }
-            }
-        }
-
-        // 링크 리스트
-        lifecycleScope.launch {
-            profileViewModel.profileLinkList.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collect { profileLinkList ->
-                linkAdapter.updateData(profileLinkList)
-
-                if (profileLinkList.isEmpty()) {
-                    binding.layoutProfileLink.visibility = View.GONE
-                } else {
-                    binding.layoutProfileLink.visibility = View.VISIBLE
-                }
-            }
-        }
-
-        // 진행한 스터디 리스트
-        lifecycleScope.launch {
-            profileViewModel.profileHostStudyList.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collect { profileHostStudyList ->
-                if (profileHostStudyList != null) {
-                    hostStudyAdapter.updateData(profileHostStudyList)
-                }
-
-                // 데이터 유무에 따른 뷰 가시성 설정
-                if (profileHostStudyList.isNullOrEmpty()) {
-                    binding.layoutListProfileHostStudy.visibility = View.GONE
-                    binding.layoutBlankProfileHostStudy.visibility = View.VISIBLE
-                } else {
-                    binding.layoutListProfileHostStudy.visibility = View.VISIBLE
-                    binding.layoutBlankProfileHostStudy.visibility = View.GONE
-                }
-
-                // 2개 이하이면 더보기 아이콘 표시 안함
-                if (profileHostStudyList != null) {
-                    if (profileHostStudyList.size < 3) {
-                        binding.layoutMoreProfileHostStudy.visibility = View.GONE
-                    }
-                }
-            }
-        }
-
-        // 참여한 스터디 리스트
-        lifecycleScope.launch {
-            profileViewModel.profilePartStudyList.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collect { profilePartStudyList ->
-                if (profilePartStudyList != null) {
-                    partStudyAdapter.updateData(profilePartStudyList)
-                }
-
-                // 데이터 유무에 따른 뷰 가시성 설정
-                if (profilePartStudyList.isNullOrEmpty()) {
-                    binding.layoutListProfilePartStudy.visibility = View.GONE
-                    binding.layoutBlankProfilePartStudy.visibility = View.VISIBLE
-                } else {
-                    binding.layoutListProfilePartStudy.visibility = View.VISIBLE
-                    binding.layoutBlankProfilePartStudy.visibility = View.GONE
-                }
-
-                // 2개 이하이면 더보기 아이콘 표시 안함
-                if (profilePartStudyList != null) {
-                    if (profilePartStudyList.size < 3) {
-                        binding.layoutMoreProfilePartStudy.visibility = View.GONE
-                    }
-                }
-            }
+    private fun extractDomain(url: String): String {
+        return try {
+            val uri = URL(url)
+            val domain = uri.host
+            if (domain.startsWith("www.")) domain.substring(4) else domain
+        } catch (e: Exception) {
+            "invalid"
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -12,14 +12,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
@@ -156,7 +153,7 @@ class ProfileFragment : Fragment() {
             Spacer(modifier = Modifier.height(8.dp))
             Text(text = name, fontSize = 18.sp, fontWeight = FontWeight.Bold)
             Spacer(modifier = Modifier.height(4.dp))
-            Text(text = intro, fontSize = 14.sp, color = CustomColor.TEXTGRAY)
+            Text(text = intro, fontSize = 14.sp, color = Color(0xFF777777))
         }
     }
 
@@ -220,6 +217,16 @@ class ProfileFragment : Fragment() {
                     )
                 }
             }
+        }
+    }
+
+    private fun extractDomain(url: String): String {
+        return try {
+            val uri = URL(url)
+            val domain = uri.host
+            if (domain.startsWith("www.")) domain.substring(4) else domain
+        } catch (e: Exception) {
+            "invalid"
         }
     }
 
@@ -339,15 +346,5 @@ class ProfileFragment : Fragment() {
         viewModel.loadUserLinkListData()
         viewModel.loadHostStudyList(userIdx!!)
         viewModel.loadPartStudyList(userIdx!!)
-    }
-
-    private fun extractDomain(url: String): String {
-        return try {
-            val uri = URL(url)
-            val domain = uri.host
-            if (domain.startsWith("www.")) domain.substring(4) else domain
-        } catch (e: Exception) {
-            "invalid"
-        }
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/theme/theme.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/theme/theme.kt
@@ -1,4 +1,39 @@
 package kr.co.lion.modigm.ui.theme
 
-class theme {
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+private val LightColorScheme = lightColorScheme(
+    primary = Color(0xFF6200EE),
+    onPrimary = Color.White,
+    secondary = Color(0xFF03DAC6),
+    onSecondary = Color.Black,
+    background = Color.White,
+    onBackground = Color.Black
+)
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Color(0xFFBB86FC),
+    onPrimary = Color.Black,
+    secondary = Color(0xFF03DAC6),
+    onSecondary = Color.Black,
+    background = Color.Black,
+    onBackground = Color.White
+)
+
+@Composable
+fun ModigmTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+//        typography = Typography, // typography 설정 추가 가능
+//        shapes = Shapes, // shapes 설정 추가 가능
+        content = content
+    )
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/theme/theme.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/theme/theme.kt
@@ -1,0 +1,4 @@
+package kr.co.lion.modigm.ui.theme
+
+class theme {
+}

--- a/app/src/main/java/kr/co/lion/modigm/util/CustomColor.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/CustomColor.kt
@@ -1,0 +1,4 @@
+package kr.co.lion.modigm.util
+
+class CustomColor {
+}

--- a/app/src/main/java/kr/co/lion/modigm/util/CustomColor.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/CustomColor.kt
@@ -1,4 +1,9 @@
 package kr.co.lion.modigm.util
 
+import androidx.compose.ui.graphics.Color
+
 class CustomColor {
+    companion object {
+        val TEXTGRAY = Color(0xFF777777)
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#423

## 📝작업 내용

프로필 화면을 Jetpack Compose로 변경하고 큰 틀을 잡음

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/1696e377-2e0b-4536-8755-d3d79e956601)

## 💬리뷰 요구사항(선택)

여백을 주면 기본 보라색 색상이 적용되어 버려서 theme 파일 추가했습니다