### PR TITLE
#438 refactor 프로필 화면 상단 compose로 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,6 +154,9 @@ dependencies {
     implementation("jp.wasabeef:glide-transformations:4.3.0")
     implementation("com.github.bumptech.glide:compose:1.0.0-alpha.1")
 
+    // Coil: 버전 3은 androidx.core:core-ktx:1.15.0를 요구해 버전 2 사용
+    implementation("io.coil-kt:coil-compose:2.5.0")
+
     // 원형 이미지 라이브러리
     implementation("de.hdodenhof:circleimageview:3.1.0")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -155,7 +155,7 @@ dependencies {
     implementation("com.github.bumptech.glide:compose:1.0.0-alpha.1")
 
     // Coil: 버전 3은 androidx.core:core-ktx:1.15.0를 요구해 버전 2 사용
-    implementation("io.coil-kt:coil-compose:2.5.0")
+    implementation("io.coil-kt:coil-compose:2.7.0")
 
     // 원형 이미지 라이브러리
     implementation("de.hdodenhof:circleimageview:3.1.0")

--- a/app/src/main/java/kr/co/lion/modigm/ui/common/ModigmTopAppBar.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/common/ModigmTopAppBar.kt
@@ -1,0 +1,32 @@
+package kr.co.lion.modigm.ui.common
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import kr.co.lion.modigm.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ModigmTopAppBar(
+    title: String,
+    onSettingsClick: () -> Unit
+) {
+    TopAppBar(
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 10.dp),
+        title = { Text(text = title) },
+        colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White),
+        actions = {
+            IconButton(onClick = onSettingsClick) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(id = R.drawable.icon_settings_24px),
+                    contentDescription = "Settings"
+                )
+            }
+        }
+    )
+}

--- a/app/src/main/java/kr/co/lion/modigm/ui/common/theme.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/common/theme.kt
@@ -1,4 +1,4 @@
-package kr.co.lion.modigm.ui.theme
+package kr.co.lion.modigm.ui.common
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.*

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -1,6 +1,7 @@
 package kr.co.lion.modigm.ui.profile
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -16,12 +17,9 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -29,11 +27,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -43,6 +40,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import kotlinx.coroutines.launch
@@ -94,11 +93,20 @@ class ProfileFragment : Fragment() {
         setupUserInfo()
     }
 
+    private fun setupUserInfo() {
+        viewModel.profileUserIdx.value = userIdx
+        viewModel.loadUserData()
+        viewModel.loadUserLinkListData()
+        viewModel.loadHostStudyList(userIdx!!)
+        viewModel.loadPartStudyList(userIdx!!)
+    }
+
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     fun ProfileScreen() {
         val profileName by viewModel.profileName.collectAsState(initial = "")
         val profileIntro by viewModel.profileIntro.collectAsState(initial = "")
+        val profilePicUrl by viewModel.profileUserImage.collectAsState(initial = "")
         val profileInterests by viewModel.profileInterests.collectAsState(initial = "")
         val profileLinks by viewModel.profileLinkList.collectAsState(initial = emptyList())
         val profileHostStudies by viewModel.profileHostStudyList.collectAsState(initial = emptyList())
@@ -121,7 +129,7 @@ class ProfileFragment : Fragment() {
                     .padding(16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                ProfileHeader(name = profileName ?: "", intro = profileIntro ?: "")
+                ProfileHeader(profileName ?: "", profileIntro ?: "", profilePicUrl ?: "")
                 Spacer(modifier = Modifier.height(16.dp))
 
                 InterestsSection(profileInterests ?: "")
@@ -157,19 +165,27 @@ class ProfileFragment : Fragment() {
     }
 
     @Composable
-    fun ProfileHeader(name: String, intro: String) {
+    fun ProfileHeader(name: String, intro: String, profilePicUrl: String?) {
+        val painter = rememberAsyncImagePainter(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(profilePicUrl)
+                .crossfade(true)
+                .build(),
+            contentScale = ContentScale.Crop,
+            error = painterResource(id = R.drawable.image_default_profile)
+        )
+
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Image(
-                painter = painterResource(id = R.drawable.image_loading_gray),
+                painter = painter,
                 contentDescription = "Profile Picture",
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .size(100.dp)
                     .clip(CircleShape)
+                    .background(Color.Gray)
             )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(text = name, fontSize = 18.sp, fontWeight = FontWeight.Bold)
-            Spacer(modifier = Modifier.height(4.dp))
+            Text(text = name, fontSize = 18.sp, fontWeight = FontWeight.Bold, modifier = Modifier.padding(top = 8.dp, bottom = 4.dp))
             Text(text = intro, fontSize = 14.sp, color = Color(0xFF777777))
         }
     }
@@ -355,13 +371,5 @@ class ProfileFragment : Fragment() {
     @Composable
     fun ProfileScreenPreview() {
         ProfileScreen()
-    }
-
-    private fun setupUserInfo() {
-        viewModel.profileUserIdx.value = userIdx
-        viewModel.loadUserData()
-        viewModel.loadUserLinkListData()
-        viewModel.loadHostStudyList(userIdx!!)
-        viewModel.loadPartStudyList(userIdx!!)
     }
 }

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -131,14 +131,18 @@ class ProfileFragment : Fragment() {
                     .padding(16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                ProfileHeader(name = profileName ?: "Default Name", intro = profileIntro ?: "Default Intro")
+                ProfileHeader(name = profileName ?: "", intro = profileIntro ?: "")
                 Spacer(modifier = Modifier.height(16.dp))
+
                 InterestsSection(profileInterests ?: "")
                 Spacer(modifier = Modifier.height(16.dp))
+
                 LinksSection(profileLinks)
                 Spacer(modifier = Modifier.height(16.dp))
+
                 StudiesSection("진행한 스터디", profileHostStudies)
                 Spacer(modifier = Modifier.height(16.dp))
+
                 StudiesSection("참여한 스터디", profilePartStudies)
             }
         }

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -113,7 +113,9 @@ class ProfileFragment : Fragment() {
                     colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White),
                     actions = {
                         IconButton(onClick = { /* TODO: Handle settings */ }) {
-                            Icon(ImageVector.vectorResource(id = R.drawable.icon_settings_24px), contentDescription = "Settings")
+                            Icon(
+                                imageVector = ImageVector.vectorResource(id = R.drawable.icon_settings_24px),
+                                contentDescription = "Settings")
                         }
                     }
                 )

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -43,7 +43,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import kotlinx.coroutines.launch
@@ -51,8 +50,8 @@ import kr.co.lion.modigm.R
 import kr.co.lion.modigm.model.StudyData
 import kr.co.lion.modigm.ui.detail.DetailFragment
 import kr.co.lion.modigm.ui.profile.vm.ProfileViewModel
-import kr.co.lion.modigm.ui.theme.ModigmTheme
-import kr.co.lion.modigm.util.CustomColor
+import kr.co.lion.modigm.ui.common.ModigmTheme
+import kr.co.lion.modigm.ui.common.ModigmTopAppBar
 import kr.co.lion.modigm.util.FragmentName
 import java.net.URL
 
@@ -107,18 +106,9 @@ class ProfileFragment : Fragment() {
 
         Scaffold(
             topBar = {
-                TopAppBar(
-                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 10.dp),
-                    title = { Text(text = "프로필") },
-                    colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White),
-                    actions = {
-                        IconButton(onClick = { changeToSettingsFragment() }) {
-                            Icon(
-                                imageVector = ImageVector.vectorResource(id = R.drawable.icon_settings_24px),
-                                contentDescription = "Settings"
-                            )
-                        }
-                    }
+                ModigmTopAppBar(
+                    title = "프로필",
+                    onSettingsClick = { changeToSettingsFragment() }
                 )
             }
         ) { paddingValues ->

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -29,9 +29,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -111,7 +113,7 @@ class ProfileFragment : Fragment() {
                     colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White),
                     actions = {
                         IconButton(onClick = { /* TODO: Handle settings */ }) {
-                            Icon(painterResource(id = R.drawable.icon_settings_24px), contentDescription = "Settings")
+                            Icon(ImageVector.vectorResource(id = R.drawable.icon_settings_24px), contentDescription = "Settings")
                         }
                     }
                 )

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -186,7 +186,7 @@ class ProfileFragment : Fragment() {
                     .background(Color.Gray)
             )
             Text(text = name, fontSize = 18.sp, fontWeight = FontWeight.Bold, modifier = Modifier.padding(top = 8.dp, bottom = 4.dp))
-            Text(text = intro, fontSize = 14.sp, color = Color(0xFF777777))
+            if (intro.isNotBlank()) Text(text = intro, fontSize = 14.sp, color = Color(0xFF777777))
         }
     }
 

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -82,7 +82,7 @@ class ProfileFragment : Fragment() {
         return ComposeView(requireContext()).apply {
             setContent {
                 ModigmTheme {
-                    ProfileScreen(viewModel = viewModel)
+                    ProfileScreen()
                 }
             }
         }
@@ -95,7 +95,7 @@ class ProfileFragment : Fragment() {
 
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
-    fun ProfileScreen(viewModel: ProfileViewModel = viewModel()) {
+    fun ProfileScreen() {
         val profileName by viewModel.profileName.collectAsState(initial = "")
         val profileIntro by viewModel.profileIntro.collectAsState(initial = "")
         val profileInterests by viewModel.profileInterests.collectAsState(initial = "")

--- a/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/kr/co/lion/modigm/ui/profile/ProfileFragment.kt
@@ -112,10 +112,11 @@ class ProfileFragment : Fragment() {
                     title = { Text(text = "프로필") },
                     colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White),
                     actions = {
-                        IconButton(onClick = { /* TODO: Handle settings */ }) {
+                        IconButton(onClick = { changeToSettingsFragment() }) {
                             Icon(
                                 imageVector = ImageVector.vectorResource(id = R.drawable.icon_settings_24px),
-                                contentDescription = "Settings")
+                                contentDescription = "Settings"
+                            )
                         }
                     }
                 )
@@ -139,6 +140,24 @@ class ProfileFragment : Fragment() {
                 StudiesSection("진행한 스터디", profileHostStudies)
                 Spacer(modifier = Modifier.height(16.dp))
                 StudiesSection("참여한 스터디", profilePartStudies)
+            }
+        }
+    }
+
+    private fun changeToSettingsFragment() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val settingsFragment = SettingsFragment()
+
+            // Fragment 교체
+            requireActivity().supportFragmentManager.commit {
+                setCustomAnimations(
+                    R.anim.slide_in,
+                    R.anim.fade_out,
+                    R.anim.fade_in,
+                    R.anim.slide_out
+                )
+                replace(R.id.containerMain, settingsFragment)
+                addToBackStack(FragmentName.SETTINGS.str)
             }
         }
     }

--- a/app/src/main/java/kr/co/lion/modigm/util/CustomColor.kt
+++ b/app/src/main/java/kr/co/lion/modigm/util/CustomColor.kt
@@ -1,9 +1,0 @@
-package kr.co.lion.modigm.util
-
-import androidx.compose.ui.graphics.Color
-
-class CustomColor {
-    companion object {
-        val TEXTGRAY = Color(0xFF777777)
-    }
-}


### PR DESCRIPTION
## #️⃣연관된 이슈

#438 

## 📝작업 내용

1. 이전 PR 피드백 중 상단 부분에 대한 항목 수정
1-1. viewModel 객체를 인자로 전달하지 않고 fragment 내에서 관리
1-2. 이미지 형식에 따라 불러오는 방식 변경
1-3. 재사용 가능한 컴포저블 분리
2. 설정 아이콘을 누르면 화면 전환되도록 구현
2-1. 이때 피드백에 따라 함수로 분리
3. 프로필 이미지 로딩
3-1. 기존 Glide가 아닌, 코틀린 코루틴이 적용되어 코틀린에 더 적합한 라이브러리인 Coli 적용

### 스크린샷

<img src="https://github.com/user-attachments/assets/a0fb48b5-91dc-47f7-a62d-496dde0a2454" height="500"/>


## 💬리뷰 요구사항(선택)

1. Coli를 적용할 때 버전 3.1.0이 가장 최신인데, 이 라이브러리가 androidx.core 0.15.0을 사용하고 있어서 저희 프로젝트보다 상위 버전이라 충돌이 일어났습니다. SDK 버전을 35로 올려야 했는데 그러면 저희가 사용하고 있는 Android Gradle Plugin에서 문제가 생길 수 있다고 해서 Coli 2.5.0을 적용했습니다. 2.5.0에 대한 사용 방법은 아래 링크에 있습니다.
안드로이드 공식문서 https://developer.android.com/develop/ui/compose/graphics/images/loading?hl=ko
Coli Github https://github.com/coil-kt/coil#jetpack-compose
Coli 공식 문서에서 버전 2에 대한 컴포즈 사용 문서 https://coil-kt.github.io/coil/upgrading_to_coil2/#compose

2. TopAppBar를 컴포저블로 분리하였습니다. 비슷한 상단바를 사용하시는 화면에서는 이 컴포저블을 그대로 사용하시면 될 것 같습니다. ui/common에 있습니다.